### PR TITLE
Fixed spelling of the word terminal

### DIFF
--- a/docs/_build/html/installation.html
+++ b/docs/_build/html/installation.html
@@ -182,7 +182,7 @@
 </pre></div>
 </div>
 </div></blockquote>
-<p><strong>Option 3. Install Retentioneering from termianl using PyPI:</strong></p>
+<p><strong>Option 3. Install Retentioneering from terminal using PyPI:</strong></p>
 <blockquote>
 <div><div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip3 install retentioneering
 </pre></div>


### PR DESCRIPTION
Fixed the spelling of the word terminal in the installation guide.