### PR TITLE
Let the MCP server start data-agnostic and load an eventstream on demand

### DIFF
--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -6,17 +6,28 @@ The MCP server runs **locally** in the Jupyter kernel, so it requires a local Py
 
 ## Starting the server
 
+You can either start the server with no context so the agent will have to upload the eventstream itself to analyse it:
 ```python
-from retentioneering.mcp import serve
+import retentioneering as rete
 
-serve(stream, context={
+rete.mcp.serve(port=8765)
+```
+
+or with context to analyse an eventstream that is already in the kernel's memory:
+
+```python
+import retentioneering as rete
+
+stream = rete.datasets.load_ecom()
+rete.mcp.serve(stream, context={
     "description": "E-commerce store. Main KPI — purchase conversion.",
     "events": {
         "purchase":    "Completed a purchase",
         "add_to_cart": "Added an item to cart",
-    },
-    "port": 8765
-})
+    }
+  },
+  port=8765
+)
 ```
 
 The `stream` argument is the [Eventstream](/docs/eventstream) you want the agent to analyse. It stays in the kernel's memory — the agent reads from it via tool calls without copying data anywhere. The optional `context` dict adds semantic information that the agent uses to write better analysis.
@@ -25,7 +36,7 @@ The `stream` argument is the [Eventstream](/docs/eventstream) you want the agent
 
 Any agent that supports MCP over SSE can connect using the server URL `http://localhost:8765/sse` (adjust the port if you changed it). Setup instructions for popular agents:
 
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/mcp) — run `claude mcp add retentioneering --transport sse http://localhost:8765/sse`
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/mcp) — run `claude mcp add --scope user --transport sse retentioneering http://localhost:8765/sse`
 - [Codex](https://developers.openai.com/codex/mcp) — add the server URL to Settings → MCP Servers → Add Server (Streamable HTTP)
 - [Cursor](https://cursor.com/docs/mcp) — add the server under Settings → Tools & MCPs → New MCP Server
 

--- a/src/retentioneering/__init__.py
+++ b/src/retentioneering/__init__.py
@@ -1,4 +1,4 @@
-from retentioneering import datasets
+from retentioneering import datasets, mcp
 from retentioneering.eventstream.eventstream import Eventstream
 from retentioneering.eventstream.schema import EventstreamSchema
 
@@ -9,4 +9,4 @@ try:
 except Exception:
     __version__ = "unknown"
 
-__all__ = ["Eventstream", "EventstreamSchema", "__version__", "datasets"]
+__all__ = ["Eventstream", "EventstreamSchema", "__version__", "datasets", "mcp"]

--- a/src/retentioneering/mcp/_prompts.py
+++ b/src/retentioneering/mcp/_prompts.py
@@ -244,7 +244,7 @@ def _static_instructions(tail: str = "") -> str:
 
 
 def _system_instructions(
-    stream: "Eventstream", context: dict, notebook_dir: str = ""
+    stream: "Eventstream | None", context: dict, notebook_dir: str = ""
 ) -> str:
     """Full system prompt for the notebook `serve()` flow: a small per-stream
     header (stats, business context) computed fresh at server-start, followed
@@ -252,16 +252,28 @@ def _system_instructions(
     cacheable (it depends on the specific stream/context passed to `serve()`)
     — platform callers skip it entirely and rely on the agent's own first
     workflow step (`describe()`) to learn the current data shape instead.
-    """
-    s = stream.schema
-    df = stream.df
-    n_paths = int(df[s.path_col].nunique())
-    events = sorted(df[s.event_col].astype(str).unique().tolist())
 
-    header = [
-        f"The stream contains {n_paths} unique paths and {len(events)} distinct events.",
-        f"Event column: '{s.event_col}'. Path column: '{s.path_col}'.",
-    ]
+    `stream` is None when `serve()` was started in data-agnostic mode (no
+    stream passed) — the header then tells the agent to call `load_data`
+    before anything else, instead of reporting stats for data that doesn't
+    exist yet.
+    """
+    if stream is None:
+        header = [
+            "No eventstream is loaded yet — serve() was started without one "
+            "(data-agnostic mode).",
+            "Call load_data(path=..., schema=...) FIRST, before any other tool "
+            "(every other tool errors until data is loaded).",
+        ]
+    else:
+        s = stream.schema
+        df = stream.df
+        n_paths = int(df[s.path_col].nunique())
+        events = sorted(df[s.event_col].astype(str).unique().tolist())
+        header = [
+            f"The stream contains {n_paths} unique paths and {len(events)} distinct events.",
+            f"Event column: '{s.event_col}'. Path column: '{s.path_col}'.",
+        ]
     if context.get("description"):
         header.append(f"Business context: {context['description']}")
     if context.get("events"):

--- a/src/retentioneering/mcp/_report_session.py
+++ b/src/retentioneering/mcp/_report_session.py
@@ -19,12 +19,29 @@ from retentioneering.mcp._agent_logic import _apply_preprocessors, _build_data_n
 
 
 class ReportSession:
-    def __init__(self, base_stream: Any, context: dict):
-        self._base_stream = base_stream  # original, never mutated
+    def __init__(self, base_stream: Any | None, context: dict | None = None):
+        self._base_stream = base_stream  # original, until load_data() replaces it
         self.active_stream = base_stream
-        self.context_events: set = set(context.get("events", {}).keys())
+        self.context: dict = context or {}
+        self.context_events: set = set(self.context.get("events", {}).keys())
         self.base_preprocessors: list = []
         self.pending_tabs: list[dict] = []
+
+    def load_data(self, stream: Any, context: dict | None = None) -> Any:
+        """Replace the base/active stream with *stream* — used by the
+        data-agnostic load_data tool, whether serve() started with no stream
+        at all or the agent wants to switch to an entirely different dataset
+        mid-session. Clears preprocessing and pending tabs from the previous
+        stream, since neither applies to the new data.
+        """
+        self._base_stream = stream
+        self.active_stream = stream
+        self.base_preprocessors = []
+        self.pending_tabs = []
+        if context is not None:
+            self.context = context
+            self.context_events = set(context.get("events", {}).keys())
+        return stream
 
     @staticmethod
     def stream_stats(stream: Any) -> dict:

--- a/src/retentioneering/mcp/server.py
+++ b/src/retentioneering/mcp/server.py
@@ -5,6 +5,7 @@ Usage in a Jupyter notebook:
     from retentioneering.mcp import serve
     serve(stream)
     serve(stream, context={"description": "...", "events": {...}})
+    serve()  # data-agnostic: agent loads data itself via the load_data tool
 
 Transport/protocol wiring only (FastMCP/SSE, `@mcp.tool()` registration,
 tracking-context tagging). Every tool is a one-line adapter over a function
@@ -43,7 +44,7 @@ __all__ = ["serve", "_apply_preprocessors", "_find_unlinked_numbers"]
 
 
 def serve(
-    stream: "Eventstream",
+    stream: "Eventstream | None" = None,
     context: dict | None = None,
     port: int = 8765,
 ) -> None:
@@ -53,7 +54,10 @@ def serve(
     Parameters
     ----------
     stream:
-        The prepared Eventstream to analyse.
+        The prepared Eventstream to analyse. Optional — omit it to start in
+        data-agnostic mode: the server has no data until the connected agent
+        calls the load_data tool with a CSV path (every other tool errors
+        with a clear message until then).
     context:
         Optional semantic layer — descriptions of events, segments, KPIs, etc.
         Example::
@@ -82,7 +86,9 @@ def serve(
         If *port* is already bound by another process (e.g. another local
         server, or an unrelated app defaulting to the same port).
     """
-    _track("mcp_serve", {"has_context": bool(context)})
+    _track(
+        "mcp_serve", {"has_context": bool(context), "has_stream": stream is not None}
+    )
     _check_port_available(port)
     mcp = _build_server(stream, context or {}, port=port, notebook_dir=os.getcwd())
     thread = threading.Thread(
@@ -123,7 +129,7 @@ def _check_port_available(port: int) -> None:
 
 
 def _build_server(
-    stream: "Eventstream",
+    stream: "Eventstream | None",
     context: dict,
     port: int = 8765,
     notebook_dir: str = "",
@@ -148,6 +154,43 @@ def _build_server(
         return decorator
 
     session = ReportSession(stream, context)
+
+    @_tool()
+    def load_data(
+        path: str, schema: dict | None = None, context: dict | None = None
+    ) -> str:
+        """
+        Load an eventstream from a local CSV file and set it as the base stream
+        for this session, replacing whatever stream is currently active (from
+        serve() or an earlier load_data call).
+
+        Call this FIRST, before any other tool, if serve() was started without
+        a stream (data-agnostic mode) — every other tool errors until this
+        succeeds. Also usable later to switch the session to an entirely
+        different dataset.
+
+        Parameters
+        ----------
+        path:
+            Path to a CSV file, readable by the process running the MCP server
+            (same filesystem as wherever serve() was invoked from).
+        schema:
+            Optional column mapping:
+              {"path_cols": [...], "event_cols": [...], "timestamp_col": "...",
+               "segment_cols": [...]}
+            Defaults to path_cols=["user_id"], event_cols=["event"],
+            timestamp_col="timestamp" for any key left unspecified.
+        context:
+            Optional semantic layer — same shape as serve()'s context argument
+            (description, events, kpis). Replaces any context set previously.
+
+        Returns
+        -------
+        JSON with updated stream stats: n_paths, n_events_total, events list.
+        """
+        return json.dumps(
+            tools.load_data(session, path, schema, context), ensure_ascii=False
+        )
 
     @_tool()
     def update_base_stream(preprocessors: list) -> str:
@@ -226,7 +269,7 @@ def _build_server(
     def describe() -> str:
         """Return schema, event list, unique path counts and available segments.
         Reflects the current active stream (after any update_base_stream calls)."""
-        return json.dumps(tools.describe(session, context), ensure_ascii=False)
+        return json.dumps(tools.describe(session, session.context), ensure_ascii=False)
 
     @_tool()
     def add_transition_graph(

--- a/src/retentioneering/mcp/tools.py
+++ b/src/retentioneering/mcp/tools.py
@@ -41,6 +41,65 @@ from retentioneering.mcp._prompts import (
 from retentioneering.mcp._report_session import ReportSession
 
 
+def _require_stream(session: Any) -> dict | None:
+    """Guard for tools that operate on the active stream. Returns an error
+    dict if serve() was started without a stream and load_data() hasn't been
+    called yet; None if a stream is present and the caller can proceed.
+    """
+    if session.active_stream is None:
+        return {
+            "error": (
+                "No eventstream loaded yet. Call load_data(path=..., schema=...) "
+                "first to load a CSV file into this session."
+            )
+        }
+    return None
+
+
+def load_data(
+    session: Any,
+    path: str,
+    schema: dict | None = None,
+    context: dict | None = None,
+) -> dict:
+    """
+    Load an eventstream from a local CSV file and set it as the base stream
+    for this session, replacing whatever stream is currently active (from
+    serve() or an earlier load_data call).
+
+    Call this FIRST, before any other tool, if serve() was started without a
+    stream (data-agnostic mode) — every other tool returns an error until
+    this succeeds. Also usable later to switch the session to an entirely
+    different dataset.
+
+    Parameters
+    ----------
+    path:
+        Path to a CSV file, readable by the process running the MCP server
+        (same filesystem as wherever serve() was invoked from).
+    schema:
+        Optional column mapping:
+          {"path_cols": [...], "event_cols": [...], "timestamp_col": "...",
+           "segment_cols": [...]}
+        Defaults to path_cols=["user_id"], event_cols=["event"],
+        timestamp_col="timestamp" for any key left unspecified.
+    context:
+        Optional semantic layer — same shape as serve()'s context argument
+        (description, events, kpis). Replaces any context set previously.
+
+    Returns
+    -------
+    Stream stats: n_paths, n_events_total, events list.
+    {"error": ...} if the file can't be read or doesn't match the schema.
+    """
+    try:
+        stream = Eventstream(path, schema=schema)
+    except Exception as exc:
+        return {"error": str(exc)}
+    session.load_data(stream, context)
+    return {"status": "data loaded", **ReportSession.stream_stats(stream)}
+
+
 def update_base_stream(session: Any, preprocessors: list) -> dict:
     """
     Apply preprocessing to the original eventstream and set it as the active
@@ -67,6 +126,8 @@ def update_base_stream(session: Any, preprocessors: list) -> dict:
     -------
     Stream stats: n_paths, n_events_total, events list.
     """
+    if (err := _require_stream(session)) is not None:
+        return err
     try:
         new_stream = session.update_base_stream(preprocessors)
     except Exception as exc:
@@ -82,6 +143,8 @@ def reset_base_stream(session: Any) -> dict:
 
     Returns updated stream stats.
     """
+    if (err := _require_stream(session)) is not None:
+        return err
     new_stream = session.reset_base_stream()
     return {
         "status": "base stream reset to original",
@@ -132,6 +195,8 @@ def describe_tool(tool: str = "") -> dict:
 def describe(session: Any, context: dict) -> dict:
     """Return schema, event list, unique path counts and available segments.
     Reflects the current active stream (after any update_base_stream calls)."""
+    if (err := _require_stream(session)) is not None:
+        return err
     cur = session.active_stream
     s = cur.schema
     ec, pc = s.event_col, s.path_col
@@ -197,6 +262,8 @@ def add_transition_graph(
         Use sparingly — prefer update_base_stream when the same preprocessing
         applies to multiple visualisations.
     """
+    if (err := _require_stream(session)) is not None:
+        return err
     src = _apply_preprocessors(session.active_stream, local_preprocessors or [])
     widget = src.transition_graph(
         edge_weight=edge_weight, diff=diff, path_col=path_col or None
@@ -262,6 +329,8 @@ def add_step_matrix(
 
     local_preprocessors: same as in add_transition_graph.
     """
+    if (err := _require_stream(session)) is not None:
+        return err
     src = _apply_preprocessors(session.active_stream, local_preprocessors or [])
     widget = src.step_matrix(
         max_steps=max_steps,
@@ -360,6 +429,8 @@ def add_segment_overview(
 
     local_preprocessors: same as in add_transition_graph.
     """
+    if (err := _require_stream(session)) is not None:
+        return err
     src = _apply_preprocessors(session.active_stream, local_preprocessors or [])
     widget = src.segment_overview(
         segment_col=segment_col,

--- a/tests/mcp/tools_test.py
+++ b/tests/mcp/tools_test.py
@@ -92,6 +92,59 @@ class TestUpdateAndResetBaseStream:
         assert session.base_preprocessors == []
 
 
+class TestLoadDataAndDataAgnosticMode:
+    def test__tools_error_before_any_data_is_loaded(self) -> None:
+        session = ReportSession(None, None)
+
+        assert "error" in tools.describe(session, session.context)
+        assert "error" in tools.update_base_stream(session, [])
+        assert "error" in tools.reset_base_stream(session)
+        assert "error" in tools.add_transition_graph(session, label="Flow")
+        assert "error" in tools.add_step_matrix(session, label="Steps")
+        assert "error" in tools.add_segment_overview(
+            session, label="Segments", segment_col="platform"
+        )
+
+    def test__load_data_populates_an_empty_session(self, tmp_path) -> None:
+        session = ReportSession(None, None)
+        csv_path = tmp_path / "events.csv"
+        get_stream().df.to_csv(csv_path, index=False)
+
+        result = tools.load_data(session, str(csv_path))
+
+        assert result["status"] == "data loaded"
+        assert set(result["events"]) >= {"view", "noise", "purchase"}
+        assert session.active_stream is not None
+        assert "error" not in tools.describe(session, session.context)
+
+    def test__load_data_sets_context(self, tmp_path) -> None:
+        session = ReportSession(None, None)
+        csv_path = tmp_path / "events.csv"
+        get_stream().df.to_csv(csv_path, index=False)
+
+        tools.load_data(session, str(csv_path), context={"description": "test biz"})
+
+        assert session.context == {"description": "test biz"}
+
+    def test__load_data_replaces_an_existing_stream_and_clears_tabs(self) -> None:
+        session = get_session()
+        tools.add_transition_graph(session, label="Overall Flow")
+        assert session.pending_tabs
+
+        result = tools.load_data(session, __file__)  # any unreadable-as-CSV path
+
+        assert "error" in result
+        # Failed load must not have touched the previous stream/tabs.
+        assert session.pending_tabs
+
+    def test__load_data_error_on_bad_path(self) -> None:
+        session = ReportSession(None, None)
+
+        result = tools.load_data(session, "/no/such/file.csv")
+
+        assert "error" in result
+
+
 class TestPlaybookAndDescribeTool:
     def test__playbook_empty_returns_index(self) -> None:
         result = tools.playbook("")


### PR DESCRIPTION
Previously serve(stream, context) required a ready-made Eventstream in the notebook's memory, so a connected agent could only ever analyse whatever was passed in at startup. Make both stream and context optional: serve() with no arguments starts the server without data, and every stream-dependent tool (describe, update_base_stream, add_transition_graph, etc.) now guards via _require_stream() and returns a clear error pointing the agent at the new load_data tool instead of crashing.

load_data(path, schema=None, context=None) reads a CSV the agent points it at, builds the Eventstream, and sets it as the session's base/active stream (also usable later to swap to a different dataset entirely, clearing any pending tabs/preprocessing from the old one). ReportSession.context is now mutable so load_data can update the semantic-context layer too, rather than it being frozen at server-start.

Also export retentioneering.mcp from the top-level package (mcp[cli] is already a hard dependency) so `import retentioneering as rete; rete.mcp.serve(port=8765)` works without a separate submodule import.