### PR TITLE
Add agent skill packages and streamline contributor setup

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,39 @@
+# Agent skills for retentioneering-tools
+
+Task-oriented skill packages for coding agents (Codex, Claude Code, and compatible
+tools). Each skill is a directory with a `SKILL.md` entry point; supporting material is
+linked from it and read on demand.
+
+| Skill | Use when |
+|---|---|
+| [`retentioneering-product-analytics/`](retentioneering-product-analytics/SKILL.md) | The user has event-level data (user, event, timestamp) or asks why users convert, churn, loop, or abandon a flow. Full workflow: inspect → recipe → execute → validate → interpret. |
+| [`retentioneering-contributing/`](retentioneering-contributing/SKILL.md) | The user found a bug, wants a feature, keeps re-writing a workaround, or asks how to open an issue/PR against this repository. Full route: capture → validate → repro → issue/PR. |
+
+## How to consume a skill (for agents without a native skill loader)
+
+1. Read the target `SKILL.md` top to bottom; its YAML frontmatter carries `name`,
+   `description` (activation criteria), and compatibility notes.
+2. Follow the workflow sections in order. Load files under `references/` only at the
+   step that cites them (they are sized to be read whole when needed).
+3. Scripts under `scripts/` are directly executable helpers; run them with the
+   project's Python environment, e.g.:
+   `python .agents/skills/retentioneering-product-analytics/scripts/inspect_event_log.py data.csv`
+4. All relative paths inside a skill resolve from that skill's directory.
+
+## Layout convention
+
+```
+<skill-name>/
+├── SKILL.md            # entry point: objective, activation, workflow
+├── references/         # deep material, linked from SKILL.md, read on demand
+└── scripts/            # executable helpers (plain Python, stdlib+pandas only)
+```
+
+The same skills are published for Claude Code under `.claude/skills/` — the content is
+identical by design; treat `.claude/skills/` as the canonical source when they diverge.
+
+## Maintenance
+
+API facts inside `references/api-map.md` are version-verified against this checkout
+(retentioneering 5.0, branch `v5-migration`). When the public API changes, re-verify the
+map's claims (it states how) and update both copies.

--- a/.agents/skills/retentioneering-contributing/SKILL.md
+++ b/.agents/skills/retentioneering-contributing/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: retentioneering-contributing
+description: >
+  Help the user turn their Retentioneering ideas, friction reports, bug
+  findings, or feature needs into high-quality upstream contributions: from
+  capturing and validating the idea, through minimal reproductions and issue
+  drafts, to preparing, testing, and submitting a pull request that follows
+  this repository's conventions. Use when the user says they found a bug,
+  wants a feature, wrote a workaround worth upstreaming, or asks how to
+  contribute, open an issue, or make a PR to retentioneering-tools.
+license: Apache-2.0
+compatibility: >
+  Requires a git checkout of retentioneering-tools, Python >= 3.11 with uv,
+  and Node.js only when JS/widget code is touched. The gh CLI is optional
+  but recommended for PR submission.
+metadata:
+  author: retentioneering
+  version: "1.0.0"
+  package: retentioneering
+  category: developer-tools
+  keywords: >-
+    open source contribution, pull request, bug report, issue template,
+    minimal reproduction, code review, oss workflow, github, retentioneering
+  homepage: https://retentioneering.com
+  documentation: https://retentioneering.com/docs
+  repository: https://github.com/retentioneering/retentioneering-tools
+---
+
+# Contributing to retentioneering-tools
+
+## Objective
+
+Convert a user's observation — a bug, a paper cut, a missing capability, a workaround
+they keep re-writing — into the smallest upstream change that would have prevented it,
+packaged so maintainers can accept it quickly.
+
+## Bundled references
+
+| File | Read it when |
+|---|---|
+| `references/repo-conventions.md` | before touching code — build/test/docs commands, architecture rules, naming, sync obligations |
+| `references/proposal-templates.md` | when drafting — issue/feature/PR templates with worked examples |
+
+## The full route: idea → merged PR
+
+### Stage 1 — Capture the observation properly (do this even for "small" ideas)
+
+Record four things while they are fresh:
+1. **Expectation** — what the user believed would happen (quote the docstring/docs page
+   that created the expectation, if any).
+2. **Reality** — what actually happened (exact error text or wrong output).
+3. **Cost** — time lost, wrong conclusion nearly shipped, workaround written.
+4. **Environment** — `retentioneering.__version__`, Python, OS, install source
+   (pip wheel vs source checkout).
+
+Field lesson: reports formatted as expectation/reality/cost/repro get acted on;
+"X is broken" reports stall.
+
+### Stage 2 — Validate against the CURRENT version
+
+Many pain points are already fixed on `v5-migration` — verify before drafting:
+
+1. `git log --oneline -30` and `CHANGELOG.md` — search keywords from the observation.
+2. Search existing issues/PRs: `gh issue list --search "<keywords>"`, `gh pr list ...`.
+3. Reproduce on the current checkout (see Stage 3). If it no longer reproduces, the
+   contribution may become a docs clarification or a regression test instead — both welcome.
+
+### Stage 3 — Minimal reproduction (the heart of a bug report)
+
+Build the smallest toy that shows the gap, e.g.:
+
+```python
+import pandas as pd
+from retentioneering import Eventstream
+df = pd.DataFrame({"user_id": ["u1","u1","u2"], "event": ["a","b","a"],
+                   "timestamp": pd.date_range("2026-01-01", periods=3, freq="1min")})
+# EXPECTED: ...       ACTUAL: ...
+```
+
+Rules: synthetic data only (never the user's real log); deterministic (fixed frames, no
+randomness without seed); one behavior per repro; assert the expectation so the repro
+doubles as a failing test.
+
+### Stage 4 — Choose the contribution shape
+
+| Situation | Shape |
+|---|---|
+| Clear defect with repro | Issue with repro; PR with fix + regression test if user wants to go further |
+| Surprising-but-documented behavior | Docs PR (docstring is the source of truth — site pages regenerate from it) |
+| Missing capability | Feature issue: use-case first, proposed signature second, evidence third (see templates) |
+| Repeated workaround in user's code | Extract as proposed API: show the workaround, its cost, the proposed call replacing it |
+| Wrong-conclusion trap (library was silent) | Frame as "missing signal": what the library knew and did not surface; propose the warning/field |
+
+For API proposals, the accepted framing (from templates): problem → evidence of frequency
+→ proposed signature → semantics incl. edge cases → acceptance criteria → migration notes.
+
+### Stage 5 — Implement (when making a PR, not just an issue)
+
+Read `references/repo-conventions.md` first. Non-negotiables:
+
+1. Fork or branch from `master`-tracking `v5-migration`; one logical change per PR.
+2. `make install` (= `uv sync` + `npm install` + **`pre-commit install`** — the last one wires
+   the git hook so commits are auto-checked). If you skip `make install`, run
+   `uv run pre-commit install` yourself before the first commit — otherwise commits bypass the
+   hooks locally and CI's `lint` job flags the formatting on your PR. Add `make build` only when
+   touching widgets/JS.
+3. Follow naming conventions (ADR-0008): `path_col/event_col/timestamp_col/session_col`,
+   `start_event/end_event`, verb-first processors, noun widgets, `<widget>_data` twins.
+4. All DuckDB execution goes through the unified query engine (L1) — no ad-hoc
+   `duckdb.sql` with replacement-scan idioms (superseded ADR-0002).
+5. Add/extend tests next to the code area (`tests/...`); a bug fix MUST include the
+   failing-before test from Stage 3.
+6. Keep the loud-and-helpful error pattern: errors that list valid values/keys are the
+   house style; silent degradation (dropped rows, empty results without a signal) is an
+   auto-reject.
+7. Sync obligations when renaming/changing API: MCP tool layer mirrors Eventstream
+   method names; JS metric editor consumes the Python metric schema; docstrings feed the
+   docs site — update all in the same PR (`uv run python docs/scripts/render_pages.py`).
+
+### Stage 6 — Pre-flight and submit
+
+```bash
+uv run pre-commit run --all-files      # ruff lint+format, gitleaks, hygiene
+uv run pytest tests/ -v                # full suite (CI runs 3.11–3.13)
+uv run python docs/scripts/render_pages.py   # if docstrings changed
+```
+
+Commit style: imperative, scoped, explaining WHY when non-obvious (see `git log` for the
+house voice). Update `CHANGELOG.md` under the unreleased/current section for
+user-visible changes.
+
+Submit:
+
+```bash
+git push -u origin <branch>
+gh pr create --title "<imperative summary>" --body-file pr_body.md
+```
+
+PR body (template in `references/proposal-templates.md`): what & why → linked issue →
+repro/before-after → tests added → sync checklist (docs/MCP/JS if applicable) →
+breaking-change note. CI must pass: `lint` + `test (3.11/3.12/3.13)`. `master` is
+PR-only; merging does not release (releases are tag-driven by maintainers).
+
+### Stage 7 — Follow through
+
+Respond to review within the PR (avoid force-push after review starts; append commits).
+If maintainers ask for direction changes, update the issue first, then the code — the
+issue is the contract.
+
+## Portfolio mode: many observations at once
+
+When the user accumulated a batch (e.g., a journal of friction from a project):
+deduplicate → verify each against current version (Stage 2) → rank by
+(frequency × silent-failure risk) → file the top 3–5 as separate issues with repros →
+offer one PR for the cheapest verified fix to build credibility, referencing the issues
+for the rest. Do not open one mega-issue.

--- a/.agents/skills/retentioneering-contributing/references/proposal-templates.md
+++ b/.agents/skills/retentioneering-contributing/references/proposal-templates.md
@@ -1,0 +1,121 @@
+# Proposal templates
+
+Copy, fill, delete unused sections. Each template ends with a worked example drawn from
+real accepted-style contributions.
+
+## T1 · Bug report (issue)
+
+```markdown
+### Expectation
+<what you believed would happen; quote the docstring/docs line that says so>
+
+### Reality
+<what happened: exact error text or wrong output>
+
+### Minimal reproduction
+​```python
+# deterministic, synthetic data, one behavior; assert the expectation
+​```
+
+### Impact
+<time lost / wrong number nearly shipped / workaround required>
+
+### Environment
+retentioneering X.Y.Z (pip wheel | source checkout @ <sha>), Python 3.x, OS
+```
+
+**Worked example (style reference).** *Expectation:* docstring says `n_clusters` accepts
+a range string `"3-8"`. *Reality:* `InvalidParameterError` from sklearn. *Repro:* 6-line
+toy stream + `cluster_analysis_data(..., n_clusters="3-8")` with `assert "best_params"
+in res`. *Impact:* 2 analysts hit it independently in one day; both fell back to lists.
+
+## T2 · Feature / API-change proposal (issue)
+
+```markdown
+### Problem (use-case first)
+<the analysis task that cannot be done cleanly today; who hits it and how often>
+
+### Today's workaround and its cost
+​```python
+# the code users write instead, and what it risks (untested, easy to get wrong)
+​```
+
+### Proposed API
+​```python
+stream.method(arg=..., new_param="...")   # exact signature
+​```
+
+### Semantics & edge cases
+<what happens on empty input, missing anchors, ties, NaN...>
+
+### Acceptance criteria
+<the tests that should pass; the error messages users should see>
+
+### Evidence
+<how often this came up; links to journals/issues/threads>
+
+### Non-goals / migration
+<what this does NOT change; deprecation path if any>
+```
+
+**Worked example.** *Problem:* windowing paths between two events drops paths lacking
+the end anchor, but anti-leakage analyses need "truncate completers, keep the rest
+whole". *Workaround:* filter_paths split → truncate half → manual concat (3 steps,
+easy to desync). *Proposed:* `truncate_paths(..., keep_unmatched="drop"|"keep_whole")`,
+default `"drop"` + warning with dropped-path count. *Acceptance:* toy where path
+`a→basket` survives with `keep_whole`; warning names counts.
+
+## T3 · "Missing signal" proposal (a special, high-value bug class)
+
+Use when the library computed something it internally knows is unreliable and returned
+it without warning (degenerate clustering picked silently; truncated table without a
+marker; rows dropped without a count). Frame:
+
+```markdown
+### What the library knew and did not surface
+### The wrong conclusion this enables   <- the key section: show the bad decision>
+### Proposed signal
+<warning text / result field / .attrs marker — smallest honest addition>
+```
+
+House rule this leans on: silent degradation is an auto-reject; loud-and-helpful is the
+style. These proposals historically get accepted fastest.
+
+## T4 · Pull request body
+
+```markdown
+## What & why
+<1-3 sentences; link the issue: Fixes #NNN>
+
+## Before / after
+​```python
+# repro from the issue; before: <error/wrong>, after: <correct>
+​```
+
+## Tests
+<added/changed tests; why they would have caught the bug>
+
+## Sync checklist
+- [ ] docstrings updated (+ render_pages regenerated if tracked)
+- [ ] MCP layer untouched or updated
+- [ ] JS metric editor / widget contract untouched or updated
+- [ ] CHANGELOG.md entry (user-visible changes)
+
+## Breaking changes
+<none | description + migration note>
+```
+
+## T5 · Docs-only PR
+
+Smallest honest fix for "surprising but working as designed": patch the DOCSTRING (the
+site renders from it), add a one-line semantics note ("labels are strings 'cluster_0'…";
+"conversion_rate is a share of ALL paths — see step_conversion_rate"), and where a
+mis-read caused a wrong number, add that as a doctest-style example.
+
+## Triage heuristics (portfolio mode)
+
+Rank a batch of observations by `frequency × silent-failure risk`:
+1. silent wrong results → file first, always;
+2. loud errors with bad messages → cheap docs/message PRs, good first contributions;
+3. missing conveniences → one consolidated feature issue each, evidence-first;
+4. style/opinion items → skip unless maintainers signal interest.

--- a/.agents/skills/retentioneering-contributing/references/repo-conventions.md
+++ b/.agents/skills/retentioneering-contributing/references/repo-conventions.md
@@ -1,0 +1,70 @@
+# Repository conventions (retentioneering-tools, branch v5-migration)
+
+Condensed from AGENTS.md, CONTRIBUTING.md, and docs/adr/ of this checkout. When in
+doubt, those files win; ADR index: `docs/adr/README.md`.
+
+## Commands
+
+```bash
+uv sync                              # python deps incl. dev group (pytest, ruff, pre-commit)
+cd js && npm install                 # only when touching JS (npm workspaces)
+make build                           # build widget.js/widget-static.js into src/retentioneering/static/
+make watch                           # vite --watch for widget UI iteration
+
+uv run pytest tests/ -v              # full suite; single file/test supported
+uv run pre-commit run --all-files    # ruff lint+format, gitleaks, hygiene hooks
+uv run python docs/scripts/render_pages.py          # regen reference docs from docstrings
+uv run python docs/scripts/generate_widget_demos.py # regen static widget demos
+```
+
+## Architecture rules that gate PRs
+
+- **Unified query engine (L1)** — all DuckDB execution goes through the query-engine
+  layer. The old "replacement scan" idiom (bare `duckdb.sql(f"... FROM df")` resolving
+  caller-scope variables; ADR-0002) is SUPERSEDED — do not reintroduce it. User-facing
+  `sql=` parameters still expose the data under the `eventstream` alias.
+- **Eventstream is immutable**: processors return new instances; `stream.df` is a
+  read-only property. Lineage is recorded (`recipe()` / `from_recipe()`) — new processors
+  must serialize into the ops model (see `ops.py`).
+- **Tools vs widgets split** (ADR-0006): headless computation in `tools/`, anywidget
+  wrappers in `widgets/`; every widget has a `<name>_data` twin whose data parameters
+  match the widget's exactly.
+- **Docstring-driven docs** (ADR-0013): the docs site's reference pages render from
+  docstrings — a docs fix is usually a docstring fix + `render_pages.py`. Guide pages
+  live in `docs/guide/*.md`.
+- **Naming** (ADR-0008): one concept, one name — `path_col`, `event_col`,
+  `timestamp_col`, `session_col`, `segment_col`; windows are `start_event`/`end_event`;
+  duration inputs are unit-strings ("30m") or Timedelta, outputs are seconds; processors
+  are verb-first, widgets are nouns; diff sentinel is `"<REST>"`.
+- **Metric schema registry**: metric parse/validate and the JS metric editor's name list
+  are generated from one schema registry — adding a metric means extending the registry,
+  not hand-editing parallel lists.
+
+## Cross-cutting sync obligations (change one → update all in the same PR)
+
+| You changed | Also update |
+|---|---|
+| Any public Eventstream method name/signature | MCP tool layer (`mcp/`), its docstrings, playbook |
+| Metric definitions | schema registry (drives both Python validation and JS editor) |
+| Widget traitlets / data contract | JS side (`js/viz-core`, `js/widget`) — Python traitlets and JS `model.get/set` keys are one protocol |
+| Docstrings of public API | `render_pages.py` regen (commit output if the repo tracks it) |
+| User-visible behavior | `CHANGELOG.md` entry |
+
+## Quality bar
+
+- Tests colocated under `tests/<area>/`; bug fixes ship with the failing-before test.
+- House error style: fail fast and helpful — list valid values/keys in the message
+  (e.g., schema errors name valid keys; metric errors name the required arg). Silent
+  data loss or silent empty results are auto-reject.
+- Determinism: seeded stochastic steps; stable ordering on timestamp ties (ORDER BY
+  timestamp, subindex in aggregations).
+- CI (GitHub Actions): `lint` + `test` matrix on Python 3.11–3.13, builds JS first.
+  `master` is protected: PRs only; release is tag-driven (`v*`), not merge-driven.
+- Telemetry code paths: never send data values — method names/arg names only; any change
+  near `_tracking.py` must preserve this and the documented opt-out.
+
+## Small map of the tree
+
+`src/retentioneering/{eventstream,data_processors,tools,widgets,metrics,mcp,utils}` ·
+`js/{viz-core,widget}` (npm workspaces → build outputs land in `src/.../static/`) ·
+`docs/{guide,adr,scripts}` · `tests/` mirrors `src` areas.

--- a/.agents/skills/retentioneering-product-analytics/SKILL.md
+++ b/.agents/skills/retentioneering-product-analytics/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: retentioneering-product-analytics
+description: >
+  Analyze event logs, clickstreams, user paths, product funnels, retention,
+  behavioral segments, transition graphs, step matrices, sequence patterns,
+  and customer journeys using Retentioneering. Use when the user provides
+  CSV, Parquet, pandas, or database event data containing user, event, and
+  timestamp columns, or asks why users convert, churn, loop, abandon a flow,
+  or follow particular product paths. Do not use for qualitative
+  journey-mapping workshops or aggregate website traffic without user-level
+  event sequences.
+license: Apache-2.0
+compatibility: >
+  Requires Python >= 3.11 and Retentioneering 5.x. Designed for local CSV,
+  Parquet, and pandas event logs. Network access is not required for local
+  analysis.
+metadata:
+  author: retentioneering
+  version: "1.0.0"
+  package: retentioneering
+  category: data-analysis
+  keywords: >-
+    clickstream, event log, user paths, customer journey, product analytics,
+    funnel analysis, retention, churn, behavioral segmentation, transition
+    graph, step matrix, sankey, sequence mining, markov chain, pandas, duckdb
+  homepage: https://retentioneering.com
+  documentation: https://retentioneering.com/docs
+  repository: https://github.com/retentioneering/retentioneering-tools
+---
+
+# Retentioneering product analytics
+
+## Objective
+
+Turn event-level behavioral data into a reproducible answer to a **product question** —
+why users convert, churn, loop, or abandon — using user trajectories, transitions,
+funnels, and behavioral segments.
+
+Do not merely generate visualizations. Connect each output to the question, separate
+observation from interpretation, and never present path correlations as causal effects.
+
+## Bundled references (read on demand, not upfront)
+
+| File | Read it when |
+|---|---|
+| `references/api-map.md` | before writing any Retentioneering call — verified signatures, argument conventions, return shapes for 5.x |
+| `references/analysis-recipes.md` | after the question is clear — 10 field-tested patterns (R1–R10) with skeletons and pitfalls |
+| `references/gotchas-and-validation.md` | before executing (API gotchas G1–G10) and before presenting (integrity checklist B1–B10) |
+| `scripts/inspect_event_log.py` | step 2 — automated data profiling and schema suggestion |
+
+## Required event-log semantics
+
+Minimum: a path identifier (user or session), an event name, a timestamp (or a reliable
+order column — see gotcha G2 for order-only data). Useful extras: session id, segment
+attributes (device, source, plan), event properties, conversion labels.
+
+## Workflow
+
+### 1. Environment
+
+1. Confirm the package: `python -c "import retentioneering; print(retentioneering.__version__)"`.
+   Expect 5.x; this skill's API map is version-verified for 5.0 — on a different major
+   version, trust installed docstrings over the map.
+2. Locate the event data (CSV / Parquet / frames in existing code). Never modify inputs.
+3. Do not invent methods: anything not in `references/api-map.md` must be verified
+   against the installed package before use.
+
+### 2. Inspect the data BEFORE choosing methods
+
+Run `scripts/inspect_event_log.py <path> [--sep ...]` (or replicate its checks inline for
+in-memory frames). It profiles columns, infers the user/event/timestamp mapping, checks
+timestamp parseability, duplicates, per-path ordering, path-length distribution, and
+emits `artifacts/data-profile.json` plus a ready-to-paste `Eventstream(...)` schema.
+
+Report to the user before proceeding: inferred mapping, row/user/event-type counts,
+covered period, and any red flags (nulls in key columns, timestamp ties, suspected bots
+or ultra-long paths, order-only timestamps). Confirm the mapping if inference is
+ambiguous.
+
+### 3. Frame the product question, then pick the SMALLEST recipe
+
+Map the question to a recipe in `references/analysis-recipes.md`:
+navigation structure/loops → transition graph (R1/R6) · before/after an anchor →
+step matrix (R3) · ordered conversion flow → funnel (R1/R2) · what winners do
+differently → diff on a funnel-stage segment (R2) · heterogeneous users → clustering
+without target leakage (R5) · between two funnel levels → truncate micro-journey (R4) ·
+intervention timing → time-to-outcome (R7) · cross-segment scan → segment overview (R8) ·
+value of a fix → Markov what-if (R9, advanced).
+
+Combine recipes only when each addition resolves a distinct uncertainty.
+
+### 4. Execute reproducibly
+
+1. Prefer a rerunnable script (or a notebook executed top-to-bottom) over ad-hoc cells.
+2. Write artifacts to a dedicated output directory (`artifacts/` by default).
+3. Log every filtering rule and its row/path impact; never silently drop data
+   (integrity item B2).
+4. Use `sample_paths(frac=, random_state=)` for stable subsamples; stochastic steps get
+   explicit seeds.
+5. Record lineage: save `processed.recipe()` and the package version into
+   `artifacts/run-metadata.json` — any artifact must be regenerable from raw data via
+   `Eventstream.from_recipe(raw_df, recipe)`.
+
+### 5. Validate before presenting
+
+Work through `references/gotchas-and-validation.md` section B. Non-negotiables:
+every percentage names its denominator; population filters are disclosed with counts;
+survivorship and exposure confounds addressed; no outcome leakage into features;
+small cells flagged with n; caption numbers come from headless `*_data` twins;
+visuals agree with tables.
+
+### 6. Interpret and deliver
+
+Structure the final answer as:
+
+1. **Observed** — numbers with denominators and n.
+2. **Interpretation** — what it likely means.
+3. **Alternative explanations** — selection, structure, censoring.
+4. **Product hypotheses** — each with the metric an experiment would move.
+5. **Suggested next analyses / A-B tests.**
+6. **Limitations.**
+
+Deliverables: analysis script or executed notebook; `artifacts/data-profile.json`;
+`artifacts/metrics.csv` (key tables); interactive HTML exports via
+`widget.export_html(..., title=, analysis=)` — write `analysis=` captions AFTER
+conclusions are final; `artifacts/summary.md` (mapping, filters, assumptions, versions,
+findings, limitations, next steps); `artifacts/run-metadata.json` (versions, parameters,
+seeds, `recipe()` lineage).

--- a/.agents/skills/retentioneering-product-analytics/references/analysis-recipes.md
+++ b/.agents/skills/retentioneering-product-analytics/references/analysis-recipes.md
@@ -1,0 +1,183 @@
+# Analysis recipes
+
+Ten field-tested patterns, each distilled from real product investigations (e-commerce
+checkout, game telemetry at 1.6M events, catalog browsing, navigation-game paths).
+Each recipe: when to use → skeleton → how to read → pitfalls. Pick the SMALLEST recipe
+that answers the question; combine only when each addition resolves a distinct uncertainty.
+
+Skeletons assume `stream` is an `Eventstream` (see `api-map.md`).
+
+---
+
+## R1 · First picture of a product ("what is going on here?")
+
+```python
+d = stream.describe(top_events=None)          # full frequency table, no truncation
+f = stream.funnel_data(steps=[...])           # your best guess of the core flow
+tg = stream.transition_graph(edge_weight="proba_out")
+tg.export_html("artifacts/overview_graph.html", title="...", analysis="...")
+```
+
+Read: `step_conversion_rate` locates the worst cliff; the graph shows where traffic
+actually goes. Pitfalls: start the funnel at a meaningful entry (not the landing page —
+many users enter mid-flow); optional steps (e.g. a review screen only 10% pass) do not
+belong in `steps`.
+
+## R2 · Converted vs dropped ("what do winners do differently?")
+
+The single highest-yield move in the toolkit.
+
+```python
+lab = stream.add_segment("stage", funnel_events=["basket", "checkout", "purchase"])
+lab.transition_graph(diff=("stage", "purchase", "basket"))     # diff = purchase − basket
+lab.step_matrix(path_pattern=".*->basket->.*", diff=("stage", "purchase", "basket"))
+```
+
+Read: positive cells = over-represented among converters. Pitfalls: `funnel_events` is
+closed/ordered — a path that hit `checkout` before ever hitting `basket` is labeled
+`basket`, target-only paths get `out_of_funnel`; check `get_segment_levels()` and group
+sizes before interpreting.
+
+## R3 · Around an anchor event ("what happens right before/after X?")
+
+```python
+(m,) = stream.step_matrix_data(max_steps=6, path_pattern=".*->basket->.*")
+m[[0, 1, 2]]        # column 0 = the anchor itself, 1..n = steps after
+```
+
+Read: rising `path_end` share right after the anchor = the anchor is where paths die.
+Pitfalls: with `path_pattern` the headless return is a tuple of per-anchor blocks —
+unpack; with `diff` it is `(blocks, g1_blocks, g2_blocks)`.
+
+## R4 · Micro-journey between two funnel levels
+
+```python
+micro = stream.truncate_paths(start_event="basket", end_event="checkout")
+micro.transition_graph(edge_weight="proba_out")
+micro.get_metrics([{"metric": "length"}, {"metric": "duration"}]).describe()
+```
+
+Read: what successful walkers actually traverse (detours, loops, help pages) and how
+long the crossing takes (median steps/minutes → timing for recovery nudges).
+Pitfalls: paths lacking either anchor are DROPPED — population = completers only. To
+compare with non-completers, split first (`filter_paths` on `has_event`), truncate each
+population by its own rules, analyze separately.
+
+## R5 · Behavioral segmentation without target leakage
+
+```python
+KEY_FAMILIES = ["listing", "product", "add_to_cart", "search", "promo"]  # NO outcome events!
+FEATURES = (
+    [{"metric": "length"}, {"metric": "duration"}, {"metric": "active_days"}]
+    + [{"metric": "event_count", "metric_args": {"event": e}} for e in KEY_FAMILIES]
+)
+res = stream.cluster_analysis_data(
+    features=FEATURES, n_clusters="3-8",
+    overview_metrics=FEATURES + [
+        {"metric": "has_event", "metric_args": {"event": "purchase"}, "agg": "mean"},
+    ],   # outcome goes HERE, for validation only
+)
+labeled = stream.add_clusters(name="behavior", features=FEATURES,
+                              n_clusters=res["best_params"]["n_clusters"])
+```
+
+Read: conversion spread ACROSS clusters (from overview) is the finding; cluster profiles
+name the personas. Pitfalls: outcome events in `features` produce silhouette≈0.9
+"clusters" that merely restate the funnel — impressive and useless. Inspect the
+silhouette curve yourself: a best-K at the range boundary or a >90/10 split means the
+clustering is weak regardless of `best_params`; on degenerate data `best_params` may be
+absent entirely. Cluster labels are strings (`"cluster_0"`); interpret via top routes and
+sizes, and treat clusters as centroids, not rules.
+
+## R6 · Loops and repeated behavior ("where do users churn in place?")
+
+Self-loops live on the transition-matrix diagonal; A→B→A patterns via `matches_pattern`:
+
+```python
+tm = stream.transition_graph_data(edge_weight="proba_out")
+selfloops = {e: tm.loc[e, e] for e in tm.index}
+pogo = stream.get_metrics([{"metric": "matches_pattern",
+                            "metric_args": {"pattern": "listing->product->listing"}}])
+```
+
+Pitfalls (both are result-killers): (1) count loops BEFORE `collapse_events(consecutive=)`
+— collapsing erases them; (2) naive "conversion of users with loop vs without" is
+confounded by exposure — longer paths have more loops AND more chances to convert;
+stratify by path-length quantiles before comparing.
+
+## R7 · Time-to-outcome and intervention windows
+
+```python
+tb = stream.get_metrics([{"metric": "time_between",
+                          "metric_args": {"start_event": "basket",
+                                          "end_event": "checkout"}}]).dropna()
+# completers' timing; for a survival view add censored paths (reached basket, no checkout)
+```
+
+Read: median/quantiles of completion → after which delay organic completion is <5% —
+that is when a nudge fires. Pitfalls: `time_between` = first A to first B globally in the
+path, not "first B after A" — for strict semantics compute from `to_dataframe()`; account
+for right-censoring near the end of the log window.
+
+## R8 · Compare segments on many metrics at once
+
+```python
+stream.segment_overview(segment_col="device", metrics=[
+    {"metric": "length", "agg": "median"},
+    {"metric": "has_event", "metric_args": {"event": "purchase"}, "agg": "mean"},
+])
+```
+
+Read: scan for the metric with the largest cross-segment gap, then drill with R2/R3.
+Pitfalls: report `n` per segment value alongside every share — a 100% on 5 paths is
+noise; flag small cells explicitly (reviewers will ask).
+
+## R9 · What-if on a Markov chain (advanced; custom math on top)
+
+Estimate the value of removing/rerouting a friction step (e.g., guest checkout):
+
+```python
+counts = sub.transition_graph_data(edge_weight="count").astype(float).fillna(0)
+# build absorbing chain on counts; edit edges (reroute basket->login mass to basket->checkout);
+# recompute absorption; bootstrap paths for CIs
+```
+
+Non-negotiables learned in the field: (1) build the chain on the RELEVANT SUB-POPULATION
+(paths containing the anchor, `truncate_paths` to first anchor→outcome) — a chain over
+the full log averages transition rows over unrelated users and badly distorts absorption;
+(2) validation gate — base-chain absorption must reproduce the observed conversion before
+any scenario is trusted; (3) plug-in absorption equals the training-set rate by
+construction, so the model's value is in scenario DELTAS, not level forecasts;
+(4) rerouted users converting like organic ones is an upper-bound assumption — present a
+sensitivity grid (25/50/100% of the empirical rate).
+
+## R10 · Package results for stakeholders
+
+```python
+w = lab.transition_graph(diff=("stage", "purchase", "basket"))
+w.export_html("artifacts/conv_vs_drop.html", title="...",
+              analysis="Findings in markdown; [basket] and [checkout] become clickable.")
+meta = {"recipe": processed.recipe(), "version": retentioneering.__version__,
+        "filters": "...", "params": {...}}
+```
+
+Rules that survived stakeholder review: write the `analysis=` text AFTER conclusions are
+final (a stale caption contradicting the report is a credibility killer); caption numbers
+must come from the headless twin, not from memory; ship `recipe()` + versions in
+`run-metadata.json` so any artifact is regenerable from raw data.
+
+---
+
+## Choosing quickly
+
+| Question shape | Recipe |
+|---|---|
+| "What's going on / where do we lose people?" | R1 → R2 |
+| "What happens around event X?" | R3 |
+| "What do successful users do between A and B?" | R4 |
+| "What kinds of users do we have?" | R5 |
+| "Why do users go in circles?" | R6 |
+| "When should we intervene?" | R7 |
+| "Which segment behaves differently?" | R8 |
+| "What is fixing X worth?" | R9 |
+| "How do I hand this to a PM?" | R10 |

--- a/.agents/skills/retentioneering-product-analytics/references/api-map.md
+++ b/.agents/skills/retentioneering-product-analytics/references/api-map.md
@@ -1,0 +1,151 @@
+# Retentioneering 5.0 — verified API map
+
+Every signature below was executed against retentioneering 5.0 (branch `v5-migration`,
+July 2026). If your installed version differs, verify before use:
+
+```python
+import retentioneering; print(retentioneering.__version__)
+```
+
+Authoritative per-method reference: docstrings in the installed package and
+https://retentioneering.com/docs. This map exists so you do not have to guess names,
+argument conventions, or return shapes.
+
+## 1. Eventstream — the hub object
+
+```python
+from retentioneering import Eventstream
+
+stream = Eventstream(df, schema={
+    "path_cols":     ["user_id"],            # path identity; nesting allowed: ["user_id","session_id"]
+    "event_cols":    ["event"],
+    "timestamp_col": "timestamp",            # REQUIRED; parseable datetimes (tz-aware OK)
+    "segment_cols":  ["device", "country"],  # categorical labels usable in every diff/overview
+    "custom_cols":   ["price"],              # carried along; visible to sql= modes
+})
+```
+
+- Defaults match columns named `user_id` / `event` / `timestamp` — `Eventstream(df)` just works then.
+- Unknown schema keys raise `SchemaConfigError` listing valid keys (trust this error).
+- Rows with null path values are rejected loudly. Numeric path ids stay numeric
+  (they are NOT cast to str) — join freely with your source frame.
+- `stream.df` is a READ-ONLY property (assignment raises). For a materialized copy use
+  `stream.to_dataframe(exclude_start_end=True)`.
+- Event names may not contain `->` (raises `SchemaConfigError` — it is the path-pattern delimiter).
+- Every processor returns a NEW Eventstream (immutable chaining).
+
+First calls on any new dataset:
+
+```python
+d = stream.describe(top_events=20)      # dict: schema, shape, date_range, event_frequency,
+                                        #       path_stats, segments
+d["event_frequency"].attrs              # {'truncated': True, 'n_total_events': N} when cut;
+                                        # pass top_events=None to disable truncation
+stream.get_event_counts()               # {event: count}
+stream.get_segment_levels()             # {segment_col: [values...]}
+```
+
+## 2. Data processors (verb-first, chainable)
+
+| Processor | Use for | Notes |
+|---|---|---|
+| `filter_events(keep=/drop=/func=/sql=)` | row-level filtering | exactly one mode; `sql=` is full DuckDB over alias `eventstream` (CTEs OK) |
+| `filter_paths(condition)` | keep whole paths by metric condition tree | leaves `{"op","metric","value","metric_args"}`; branches `and/or/not`; top-level list = AND; raises `EmptyEventstreamError` when nothing survives |
+| `add_segment(name, rules=/func=/sql=/funnel_events=)` | add a segment column | `funnel_events` labels each path by the furthest step reached IN ORDER (closed funnel); non-reachers get `"out_of_funnel"` |
+| `add_clusters(name, features, n_clusters, ...)` | materialize clusters as a segment column | labels are strings `"cluster_0"...`; deterministic (seeded) |
+| `add_start_end_events()` | explicit `path_start`/`path_end` rows | idempotent; widgets add them implicitly |
+| `rename_events(mapping)` | collapse taxonomies (e.g. `"PLP: *"` families by explicit dict) | unknown keys raise |
+| `collapse_events(consecutive=True | [...])` | dedupe consecutive repeats | count loops BEFORE collapsing if loops are your subject |
+| `split_sessions(timeout="30m" | separator= | start_event=+end_event=)` | derive sessions | duration strings need units; column params use `session_col` naming |
+| `truncate_paths(start_event, end_event)` | window each path between two events | `path_start`/`path_end` sentinels supported; paths missing either anchor are DROPPED — see gotchas for the keep-whole pattern |
+| `drop_events / drop_segment / edit_events / rename_segment_levels / sample_paths / to_daily_states / urls_to_events / add_events` | as named | `sample_paths(frac=, random_state=)` for stable subsamples |
+
+## 3. Metrics registry — one config format everywhere
+
+Used by `get_metrics(list)`, `filter_paths(condition)`, `cluster_analysis*(features=/overview_metrics=)`,
+`segment_overview(metrics=)`.
+
+```python
+stream.get_metrics([
+    {"metric": "length"},
+    {"metric": "duration"},                                            # seconds
+    {"metric": "event_count",   "metric_args": {"event": "basket"}},   # SINGLE event → key 'event'
+    {"metric": "has_event",     "metric_args": {"event": "purchase"}},
+    {"metric": "has_any_event", "metric_args": {"events": ["a","b"]}}, # LIST → key 'events' (OR)
+    {"metric": "has_all_events","metric_args": {"events": ["a","b"]}}, # LIST → key 'events' (AND)
+    {"metric": "time_between",  "metric_args": {"start_event": "basket",
+                                                "end_event": "purchase"}},
+    {"metric": "matches_pattern","metric_args": {"pattern": "basket->.*->purchase"}},
+])   # -> DataFrame indexed by path id
+```
+
+Argument-key convention (this exact split is version-verified):
+**single event → `event` (string); multiple events → `events` (list) and only on
+`has_any_event` / `has_all_events`.** Wrong keys raise `InvalidMetricConfigError`
+naming the requirement.
+
+Other metrics: `active_days`, `first_event_time`, `in_segment` (modes `any/all/event_share`).
+`matches_pattern` is token-wise (no substring false-positives) and order-deterministic.
+`time_between` measures first occurrence of A to first occurrence of B **globally in the
+path** (not "first B after A") — verify fit for your question.
+
+## 4. Tools: widgets + headless twins
+
+Every widget has a headless `<name>_data(...)` twin returning plain data with the same
+data parameters. Common widget params: `diff=`, `path_col=`, `height=`, `sidebar_open=`,
+`state_file=`.
+
+| Widget | Headless returns | Key params |
+|---|---|---|
+| `transition_graph` | events×events DataFrame | `edge_weight` ∈ `proba_out, proba_in, count, unique_paths, share_of_total, avg_per_path, time_median, time_q95` |
+| `step_matrix` / `step_sankey` | no `path_pattern`: DataFrame; with `path_pattern`: tuple of per-anchor blocks; with pattern+diff: `(blocks, g1_blocks, g2_blocks)` | `max_steps`, `path_pattern=".*->X->.*"` — the anchor event sits at column **0** |
+| `funnel` | dict; each step has `unique_paths`, `conversion_rate` (share of ALL paths) **and `step_conversion_rate`** (step-to-step) | `steps=[...]` — closed/ordered semantics: a path counts at step N only after passing all previous |
+| `segment_overview` | DataFrame metrics×segment values | `metrics=[...]` with `agg` |
+| `cluster_analysis` | dict: `overview_df`, `silhouette` (`{"params": [...], "silhouette": [...]}`), `cluster_labels`, `best_params` | `n_clusters` accepts int, list, or range string `"3-8"`; features = metric configs |
+
+**diff semantics:** `diff=(segment_col, v1, v2)` (also `(path_ids1, path_ids2)`; `v2` may be
+`"<REST>"`). Returned diff block = **value1 − value2**. Segment values must match exactly
+(check `get_segment_levels()`).
+
+## 5. Deliverables: standalone interactive HTML
+
+```python
+w = stream.transition_graph(diff=("device", "mobile", "desktop"))
+w.export_html("artifacts/graph.html",
+              title="Mobile vs desktop",
+              analysis="Markdown text; [event_name] references become clickable node links.")
+```
+
+- `export_html` is a method of the **widget**, not the stream.
+- Files are fully self-contained (~1.2 MB, no CDN) — safe to attach or email.
+- A failed recompute raises `WidgetExportError` (no silent empty exports).
+- Widgets construct headlessly in plain scripts — Jupyter is not required for export.
+
+## 6. Reproducibility: lineage recipes
+
+Processor chains are recorded and replayable:
+
+```python
+processed = stream.filter_events(drop={"event": ["noise"]}).rename_events({"a": "A"})
+rec = processed.recipe()                     # JSON-serializable list of ops
+replayed = Eventstream.from_recipe(raw_df, rec)   # re-applies the same chain
+```
+
+Persist `rec` in run metadata so any artifact can be regenerated from raw data.
+
+## 7. MCP server (agent-driven analysis)
+
+```python
+import retentioneering.mcp as mcp
+mcp.serve()                    # data-agnostic: agent loads an eventstream on demand
+mcp.serve(stream, port=8765)   # or pre-loaded; raises OSError if port is taken
+```
+
+## 8. Environment notes
+
+- Requires Python ≥ 3.11. Backend is an embedded engine (DuckDB family) — millions of rows
+  run in seconds on a laptop; no network needed.
+- Interactive widgets from a *source checkout* need the JS bundle built (`make build`,
+  Node required). pip-installed wheels ship the bundle.
+- Telemetry: the library reports anonymous usage (method names, never data);
+  see the docs "Tracking" page for scope and opt-out.

--- a/.agents/skills/retentioneering-product-analytics/references/gotchas-and-validation.md
+++ b/.agents/skills/retentioneering-product-analytics/references/gotchas-and-validation.md
@@ -1,0 +1,70 @@
+# Gotchas and validation
+
+Two lists with different natures. **API gotchas**: current library behaviors that
+surprise; work around them as described. **Analysis integrity**: methodological traps
+that produced wrong-but-plausible conclusions in real investigations until a reviewer
+caught them; validate against each before shipping numbers.
+
+## A. API gotchas (version-verified)
+
+| # | Behavior | Handle it |
+|---|---|---|
+| G1 | `truncate_paths` DROPS paths missing either anchor; there is no keep-whole option | for "truncate converters, keep the rest whole": `filter_paths` split → truncate the converter half → analyze separately (concatenating streams is manual) |
+| G2 | No order-only mode: `timestamp_col` is mandatory | for logs with click order but no clock: synthesize `base_date + order * 1s`; then durations/`time_median` are MEANINGLESS — never report them, only step counts |
+| G3 | `time_between` = first A to first B **globally**, not first-B-after-A | off-by-few on paths where B precedes A; compute strict semantics via `to_dataframe()` when it matters |
+| G4 | `funnel` is closed/ordered only | for presence-based ("did all of these happen, any order") use `has_all_events` via `get_metrics` |
+| G5 | Metric arg keys: single event → `event`, lists → `events` (only on `has_any_event`/`has_all_events`) | copy from api-map, not from memory; errors are loud and name the requirement |
+| G6 | Cluster result may LACK `best_params` when silhouette is undefined for every candidate (degenerate/duplicate feature rows) | guard `res.get("best_params")`; treat as "no cluster structure" |
+| G7 | Cluster labels are strings `"cluster_0"...`; diff values must match segment levels exactly | check `get_segment_levels()` before writing `diff=(...)` |
+| G8 | Transition matrix may be integer-typed with NaN gaps | before matrix math: `.astype(float).fillna(0)` |
+| G9 | Graph widgets with >~100 nodes open as a dense hairball | teach the edge-weight threshold in the sidebar; or pre-aggregate events into families (`rename_events`) |
+| G10 | `stream.df` is read-only | mutate via processors; materialize with `to_dataframe()` |
+
+Fixed in 5.0 — do NOT carry these legacy workarounds forward: identifier quoting for
+SQL-reserved column names; nondeterministic `matches_pattern` ordering; `n_clusters`
+range strings; silent `describe()` truncation (now flagged in `.attrs`, disable with
+`top_events=None`); silent empty widget exports (now `WidgetExportError`); substring
+pattern matching; anchor off-by-one in step matrix; `diff` sign (now v1−v2).
+
+## B. Analysis integrity checklist
+
+Run before presenting conclusions. Each item traces to a real wrong-conclusion incident.
+
+1. **Denominators.** Every percentage names its base. `funnel_data.conversion_rate` is
+   share of ALL paths; step-to-step is `step_conversion_rate`. *(Incident: "2% conversion"
+   nearly shipped where the true step rate was 32%.)*
+2. **Population.** Who exactly is in the analysis? Watch entry filters (`truncate_paths`
+   drops non-completers, G1) and "engaged users only" thresholds. *(Incident: a ≥10-min
+   activity cutoff silently excluded 43% — the weakest users, the ones the decision was
+   about; on the full cohort the verdict got harsher, not softer.)*
+3. **Survivorship.** Late-stage aggregates describe survivors. Report "of all who
+   started / of those who reached" side by side. Ratings/feedback exist only for
+   finishers.
+4. **Exposure confound.** Longer paths contain more of everything (loops, feature
+   touches) AND convert more. Any "users who did X convert better" claim needs
+   stratification by path length or a matched design.
+5. **Target leakage.** No outcome events in clustering features (R5) or in
+   sequence/pattern features computed over the full path — cut paths at the first
+   outcome before mining predictive patterns.
+6. **Structural vs behavioral lift.** If the flow FORCES step A before outcome B, "users
+   who did A convert ×100" is architecture, not behavior. Say which one you measured.
+7. **Small cells.** Shares without `n` are noise bait; flag cells with n below ~30 and
+   add intervals (Wilson for proportions) when a decision hangs on them.
+8. **Right/left censoring.** Log windows cut both ends: "never returned" near the window
+   edge and "first session" of users active before the window are both suspect.
+9. **Correlation discipline.** Observational path data supports "associated with", not
+   "drives", unless there is an experiment. End reports with hypotheses + suggested A/B,
+   not causal claims.
+10. **Numbers ↔ visuals.** Every caption number comes from the headless twin of the
+    widget shown; write `analysis=` texts after conclusions are frozen.
+
+## C. Self-checks worth automating
+
+```python
+# conservation: filters explain themselves
+before = stream.describe()["shape"]; after = filtered.describe()["shape"]
+# funnel sanity: step counts are non-increasing
+# diff sanity: diff block equals g1 - g2 on a sample cell
+# determinism: rerun the pipeline; assert identical key outputs
+# reproducibility: Eventstream.from_recipe(raw_df, processed.recipe()) equals processed
+```

--- a/.agents/skills/retentioneering-product-analytics/scripts/inspect_event_log.py
+++ b/.agents/skills/retentioneering-product-analytics/scripts/inspect_event_log.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python
+"""Profile an event log and suggest a Retentioneering Eventstream schema.
+
+Usage:
+    python inspect_event_log.py PATH [--sep SEP] [--user-col C] [--event-col C]
+                                [--ts-col C] [--sample-rows N] [--out DIR]
+
+Reads CSV/TSV/Parquet, infers user/event/timestamp columns when not given,
+runs data-quality checks, writes artifacts/data-profile.json, and prints a
+human report plus a ready-to-paste Eventstream(...) snippet.
+
+Only requires pandas. If retentioneering is importable, its version is recorded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+import pandas as pd
+
+USER_HINTS = (
+    "user_id",
+    "user",
+    "client_id",
+    "customer_id",
+    "uid",
+    "session_id",
+    "hashed",
+    "player",
+    "visitor",
+)
+EVENT_HINTS = ("event_name", "event", "action", "event_type_name", "page", "screen")
+TS_HINTS = ("timestamp", "event_time", "time", "datetime", "ts", "date")
+SEGMENT_HINTS = (
+    "device",
+    "platform",
+    "country",
+    "source",
+    "utm",
+    "channel",
+    "plan",
+    "os",
+    "browser",
+    "campaign",
+    "medium",
+    "group_name",
+    "variant",
+)
+
+
+def sniff_sep(path: str) -> str:
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        head = fh.readline()
+    for sep in ("\t", ";", ",", "|"):
+        if head.count(sep) >= 2:
+            return sep
+    return ","
+
+
+def pick(columns, hints, taken):
+    lowered = {c.lower(): c for c in columns}
+    for h in hints:
+        for lc, orig in lowered.items():
+            if h == lc and orig not in taken:
+                return orig
+    for h in hints:
+        for lc, orig in lowered.items():
+            if h in lc and orig not in taken:
+                return orig
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("path")
+    ap.add_argument("--sep", default=None)
+    ap.add_argument("--user-col", default=None)
+    ap.add_argument("--event-col", default=None)
+    ap.add_argument("--ts-col", default=None)
+    ap.add_argument(
+        "--sample-rows",
+        type=int,
+        default=None,
+        help="read only the first N rows (for very large files)",
+    )
+    ap.add_argument("--out", default="artifacts")
+    a = ap.parse_args()
+
+    if a.path.endswith((".parquet", ".pq")):
+        df = pd.read_parquet(a.path)
+        sep = None
+    else:
+        sep = a.sep or sniff_sep(a.path)
+        df = pd.read_csv(a.path, sep=sep, nrows=a.sample_rows, low_memory=False)
+
+    cols = list(df.columns)
+    taken: set = set()
+    user_col = a.user_col or pick(cols, USER_HINTS, taken)
+    taken.add(user_col)
+    event_col = a.event_col or pick(cols, EVENT_HINTS, taken)
+    taken.add(event_col)
+    ts_col = a.ts_col or pick(cols, TS_HINTS, taken)
+    taken.add(ts_col)
+    segment_cols = [
+        c
+        for c in cols
+        if c not in taken
+        and any(h in c.lower() for h in SEGMENT_HINTS)
+        and df[c].nunique(dropna=True) <= max(50, len(df) // 100)
+    ]
+
+    problems: list[str] = []
+    if not user_col or not event_col:
+        problems.append(
+            "could not infer user/event columns — pass --user-col/--event-col"
+        )
+
+    profile: dict = {
+        "path": os.path.abspath(a.path),
+        "sep": sep,
+        "rows_read": int(len(df)),
+        "sampled": a.sample_rows is not None,
+        "columns": cols,
+        "inferred": {
+            "user_col": user_col,
+            "event_col": event_col,
+            "ts_col": ts_col,
+            "segment_candidates": segment_cols,
+        },
+    }
+
+    if user_col and event_col:
+        nulls_user = int(df[user_col].isna().sum())
+        nulls_event = int(df[event_col].isna().sum())
+        profile["n_paths"] = int(df[user_col].nunique(dropna=True))
+        profile["n_event_types"] = int(df[event_col].nunique(dropna=True))
+        profile["nulls"] = {"user": nulls_user, "event": nulls_event}
+        if nulls_user:
+            problems.append(
+                f"{nulls_user} rows with null {user_col} — Eventstream will "
+                "reject them; decide drop/repair explicitly"
+            )
+        top = df[event_col].value_counts()
+        profile["top_events"] = {str(k): int(v) for k, v in top.head(25).items()}
+        share = float(top.iloc[0]) / max(len(df), 1)
+        if share > 0.30:
+            problems.append(
+                f"event '{top.index[0]}' is {share:.0%} of all rows — likely "
+                "noise (heartbeat/dialogue); consider drop_events before path tools"
+            )
+        plen = df.groupby(user_col, dropna=True).size()
+        profile["path_length"] = {
+            q: float(plen.quantile(x))
+            for q, x in [("p50", 0.5), ("p90", 0.9), ("p99", 0.99)]
+        } | {"max": int(plen.max()), "n_len1": int((plen == 1).sum())}
+        if plen.max() > 50 * max(plen.median(), 1):
+            problems.append(
+                f"max path length {plen.max()} vs median {plen.median():.0f} "
+                "— check bots/shared accounts"
+            )
+
+    ts_ok = False
+    if ts_col:
+        parsed = pd.to_datetime(df[ts_col], errors="coerce", utc=True, format="mixed")
+        bad = int(parsed.isna().sum())
+        ts_ok = bad == 0
+        profile["timestamp"] = {
+            "unparseable": bad,
+            "min": str(parsed.min()),
+            "max": str(parsed.max()),
+        }
+        if bad:
+            problems.append(f"{bad} unparseable timestamps in {ts_col}")
+        if user_col:
+            ties = int(df.assign(_p=parsed).duplicated([user_col, "_p"]).sum())
+            profile["timestamp"]["within_path_ties"] = ties
+            if ties:
+                problems.append(
+                    f"{ties} same-timestamp ties within paths — ensure a "
+                    "stable secondary order (row order is preserved)"
+                )
+        dup = int(df.duplicated([c for c in (user_col, event_col, ts_col) if c]).sum())
+        profile["exact_duplicates"] = dup
+        if dup:
+            problems.append(
+                f"{dup} exact duplicate (user,event,ts) rows — dedupe or justify"
+            )
+    else:
+        problems.append(
+            "no timestamp column found — if only an order column exists, "
+            "synthesize base_date + order*1s and NEVER report durations (gotcha G2)"
+        )
+
+    try:
+        import retentioneering
+
+        profile["retentioneering_version"] = retentioneering.__version__
+    except Exception:
+        profile["retentioneering_version"] = None
+        problems.append("retentioneering not importable in this environment")
+
+    profile["problems"] = problems
+
+    os.makedirs(a.out, exist_ok=True)
+    out_path = os.path.join(a.out, "data-profile.json")
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump(profile, fh, indent=2, ensure_ascii=False, default=str)
+
+    print(
+        f"rows={profile['rows_read']:,}  paths={profile.get('n_paths', '?'):,}  "
+        f"event_types={profile.get('n_event_types', '?')}"
+    )
+    if ts_col and "timestamp" in profile:
+        print(f"period: {profile['timestamp']['min']} .. {profile['timestamp']['max']}")
+    print(
+        f"inferred: user={user_col}  event={event_col}  ts={ts_col}  "
+        f"segments={segment_cols}"
+    )
+    for p in problems:
+        print(f"  ⚠ {p}")
+    print(f"\nprofile written: {out_path}\n")
+    print("suggested schema:\n")
+    seg = ", ".join(f'"{c}"' for c in segment_cols)
+    print(f"""from retentioneering import Eventstream
+stream = Eventstream(df, schema={{
+    "path_cols": ["{user_col}"],
+    "event_cols": ["{event_col}"],
+    "timestamp_col": "{ts_col}",
+    "segment_cols": [{seg}],
+}})
+stream.describe()""")
+    return 1 if (not user_col or not event_col or not ts_ok) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/retentioneering-contributing/SKILL.md
+++ b/.claude/skills/retentioneering-contributing/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: retentioneering-contributing
+description: >
+  Help the user turn their Retentioneering ideas, friction reports, bug
+  findings, or feature needs into high-quality upstream contributions: from
+  capturing and validating the idea, through minimal reproductions and issue
+  drafts, to preparing, testing, and submitting a pull request that follows
+  this repository's conventions. Use when the user says they found a bug,
+  wants a feature, wrote a workaround worth upstreaming, or asks how to
+  contribute, open an issue, or make a PR to retentioneering-tools.
+license: Apache-2.0
+compatibility: >
+  Requires a git checkout of retentioneering-tools, Python >= 3.11 with uv,
+  and Node.js only when JS/widget code is touched. The gh CLI is optional
+  but recommended for PR submission.
+metadata:
+  author: retentioneering
+  version: "1.0.0"
+  package: retentioneering
+  category: developer-tools
+  keywords: >-
+    open source contribution, pull request, bug report, issue template,
+    minimal reproduction, code review, oss workflow, github, retentioneering
+  homepage: https://retentioneering.com
+  documentation: https://retentioneering.com/docs
+  repository: https://github.com/retentioneering/retentioneering-tools
+---
+
+# Contributing to retentioneering-tools
+
+## Objective
+
+Convert a user's observation — a bug, a paper cut, a missing capability, a workaround
+they keep re-writing — into the smallest upstream change that would have prevented it,
+packaged so maintainers can accept it quickly.
+
+## Bundled references
+
+| File | Read it when |
+|---|---|
+| `references/repo-conventions.md` | before touching code — build/test/docs commands, architecture rules, naming, sync obligations |
+| `references/proposal-templates.md` | when drafting — issue/feature/PR templates with worked examples |
+
+## The full route: idea → merged PR
+
+### Stage 1 — Capture the observation properly (do this even for "small" ideas)
+
+Record four things while they are fresh:
+1. **Expectation** — what the user believed would happen (quote the docstring/docs page
+   that created the expectation, if any).
+2. **Reality** — what actually happened (exact error text or wrong output).
+3. **Cost** — time lost, wrong conclusion nearly shipped, workaround written.
+4. **Environment** — `retentioneering.__version__`, Python, OS, install source
+   (pip wheel vs source checkout).
+
+Field lesson: reports formatted as expectation/reality/cost/repro get acted on;
+"X is broken" reports stall.
+
+### Stage 2 — Validate against the CURRENT version
+
+Many pain points are already fixed on `v5-migration` — verify before drafting:
+
+1. `git log --oneline -30` and `CHANGELOG.md` — search keywords from the observation.
+2. Search existing issues/PRs: `gh issue list --search "<keywords>"`, `gh pr list ...`.
+3. Reproduce on the current checkout (see Stage 3). If it no longer reproduces, the
+   contribution may become a docs clarification or a regression test instead — both welcome.
+
+### Stage 3 — Minimal reproduction (the heart of a bug report)
+
+Build the smallest toy that shows the gap, e.g.:
+
+```python
+import pandas as pd
+from retentioneering import Eventstream
+df = pd.DataFrame({"user_id": ["u1","u1","u2"], "event": ["a","b","a"],
+                   "timestamp": pd.date_range("2026-01-01", periods=3, freq="1min")})
+# EXPECTED: ...       ACTUAL: ...
+```
+
+Rules: synthetic data only (never the user's real log); deterministic (fixed frames, no
+randomness without seed); one behavior per repro; assert the expectation so the repro
+doubles as a failing test.
+
+### Stage 4 — Choose the contribution shape
+
+| Situation | Shape |
+|---|---|
+| Clear defect with repro | Issue with repro; PR with fix + regression test if user wants to go further |
+| Surprising-but-documented behavior | Docs PR (docstring is the source of truth — site pages regenerate from it) |
+| Missing capability | Feature issue: use-case first, proposed signature second, evidence third (see templates) |
+| Repeated workaround in user's code | Extract as proposed API: show the workaround, its cost, the proposed call replacing it |
+| Wrong-conclusion trap (library was silent) | Frame as "missing signal": what the library knew and did not surface; propose the warning/field |
+
+For API proposals, the accepted framing (from templates): problem → evidence of frequency
+→ proposed signature → semantics incl. edge cases → acceptance criteria → migration notes.
+
+### Stage 5 — Implement (when making a PR, not just an issue)
+
+Read `references/repo-conventions.md` first. Non-negotiables:
+
+1. Fork or branch from `master`-tracking `v5-migration`; one logical change per PR.
+2. `make install` (= `uv sync` + `npm install` + **`pre-commit install`** — the last one wires
+   the git hook so commits are auto-checked). If you skip `make install`, run
+   `uv run pre-commit install` yourself before the first commit — otherwise commits bypass the
+   hooks locally and CI's `lint` job flags the formatting on your PR. Add `make build` only when
+   touching widgets/JS.
+3. Follow naming conventions (ADR-0008): `path_col/event_col/timestamp_col/session_col`,
+   `start_event/end_event`, verb-first processors, noun widgets, `<widget>_data` twins.
+4. All DuckDB execution goes through the unified query engine (L1) — no ad-hoc
+   `duckdb.sql` with replacement-scan idioms (superseded ADR-0002).
+5. Add/extend tests next to the code area (`tests/...`); a bug fix MUST include the
+   failing-before test from Stage 3.
+6. Keep the loud-and-helpful error pattern: errors that list valid values/keys are the
+   house style; silent degradation (dropped rows, empty results without a signal) is an
+   auto-reject.
+7. Sync obligations when renaming/changing API: MCP tool layer mirrors Eventstream
+   method names; JS metric editor consumes the Python metric schema; docstrings feed the
+   docs site — update all in the same PR (`uv run python docs/scripts/render_pages.py`).
+
+### Stage 6 — Pre-flight and submit
+
+```bash
+uv run pre-commit run --all-files      # ruff lint+format, gitleaks, hygiene
+uv run pytest tests/ -v                # full suite (CI runs 3.11–3.13)
+uv run python docs/scripts/render_pages.py   # if docstrings changed
+```
+
+Commit style: imperative, scoped, explaining WHY when non-obvious (see `git log` for the
+house voice). Update `CHANGELOG.md` under the unreleased/current section for
+user-visible changes.
+
+Submit:
+
+```bash
+git push -u origin <branch>
+gh pr create --title "<imperative summary>" --body-file pr_body.md
+```
+
+PR body (template in `references/proposal-templates.md`): what & why → linked issue →
+repro/before-after → tests added → sync checklist (docs/MCP/JS if applicable) →
+breaking-change note. CI must pass: `lint` + `test (3.11/3.12/3.13)`. `master` is
+PR-only; merging does not release (releases are tag-driven by maintainers).
+
+### Stage 7 — Follow through
+
+Respond to review within the PR (avoid force-push after review starts; append commits).
+If maintainers ask for direction changes, update the issue first, then the code — the
+issue is the contract.
+
+## Portfolio mode: many observations at once
+
+When the user accumulated a batch (e.g., a journal of friction from a project):
+deduplicate → verify each against current version (Stage 2) → rank by
+(frequency × silent-failure risk) → file the top 3–5 as separate issues with repros →
+offer one PR for the cheapest verified fix to build credibility, referencing the issues
+for the rest. Do not open one mega-issue.

--- a/.claude/skills/retentioneering-contributing/references/proposal-templates.md
+++ b/.claude/skills/retentioneering-contributing/references/proposal-templates.md
@@ -1,0 +1,121 @@
+# Proposal templates
+
+Copy, fill, delete unused sections. Each template ends with a worked example drawn from
+real accepted-style contributions.
+
+## T1 · Bug report (issue)
+
+```markdown
+### Expectation
+<what you believed would happen; quote the docstring/docs line that says so>
+
+### Reality
+<what happened: exact error text or wrong output>
+
+### Minimal reproduction
+​```python
+# deterministic, synthetic data, one behavior; assert the expectation
+​```
+
+### Impact
+<time lost / wrong number nearly shipped / workaround required>
+
+### Environment
+retentioneering X.Y.Z (pip wheel | source checkout @ <sha>), Python 3.x, OS
+```
+
+**Worked example (style reference).** *Expectation:* docstring says `n_clusters` accepts
+a range string `"3-8"`. *Reality:* `InvalidParameterError` from sklearn. *Repro:* 6-line
+toy stream + `cluster_analysis_data(..., n_clusters="3-8")` with `assert "best_params"
+in res`. *Impact:* 2 analysts hit it independently in one day; both fell back to lists.
+
+## T2 · Feature / API-change proposal (issue)
+
+```markdown
+### Problem (use-case first)
+<the analysis task that cannot be done cleanly today; who hits it and how often>
+
+### Today's workaround and its cost
+​```python
+# the code users write instead, and what it risks (untested, easy to get wrong)
+​```
+
+### Proposed API
+​```python
+stream.method(arg=..., new_param="...")   # exact signature
+​```
+
+### Semantics & edge cases
+<what happens on empty input, missing anchors, ties, NaN...>
+
+### Acceptance criteria
+<the tests that should pass; the error messages users should see>
+
+### Evidence
+<how often this came up; links to journals/issues/threads>
+
+### Non-goals / migration
+<what this does NOT change; deprecation path if any>
+```
+
+**Worked example.** *Problem:* windowing paths between two events drops paths lacking
+the end anchor, but anti-leakage analyses need "truncate completers, keep the rest
+whole". *Workaround:* filter_paths split → truncate half → manual concat (3 steps,
+easy to desync). *Proposed:* `truncate_paths(..., keep_unmatched="drop"|"keep_whole")`,
+default `"drop"` + warning with dropped-path count. *Acceptance:* toy where path
+`a→basket` survives with `keep_whole`; warning names counts.
+
+## T3 · "Missing signal" proposal (a special, high-value bug class)
+
+Use when the library computed something it internally knows is unreliable and returned
+it without warning (degenerate clustering picked silently; truncated table without a
+marker; rows dropped without a count). Frame:
+
+```markdown
+### What the library knew and did not surface
+### The wrong conclusion this enables   <- the key section: show the bad decision>
+### Proposed signal
+<warning text / result field / .attrs marker — smallest honest addition>
+```
+
+House rule this leans on: silent degradation is an auto-reject; loud-and-helpful is the
+style. These proposals historically get accepted fastest.
+
+## T4 · Pull request body
+
+```markdown
+## What & why
+<1-3 sentences; link the issue: Fixes #NNN>
+
+## Before / after
+​```python
+# repro from the issue; before: <error/wrong>, after: <correct>
+​```
+
+## Tests
+<added/changed tests; why they would have caught the bug>
+
+## Sync checklist
+- [ ] docstrings updated (+ render_pages regenerated if tracked)
+- [ ] MCP layer untouched or updated
+- [ ] JS metric editor / widget contract untouched or updated
+- [ ] CHANGELOG.md entry (user-visible changes)
+
+## Breaking changes
+<none | description + migration note>
+```
+
+## T5 · Docs-only PR
+
+Smallest honest fix for "surprising but working as designed": patch the DOCSTRING (the
+site renders from it), add a one-line semantics note ("labels are strings 'cluster_0'…";
+"conversion_rate is a share of ALL paths — see step_conversion_rate"), and where a
+mis-read caused a wrong number, add that as a doctest-style example.
+
+## Triage heuristics (portfolio mode)
+
+Rank a batch of observations by `frequency × silent-failure risk`:
+1. silent wrong results → file first, always;
+2. loud errors with bad messages → cheap docs/message PRs, good first contributions;
+3. missing conveniences → one consolidated feature issue each, evidence-first;
+4. style/opinion items → skip unless maintainers signal interest.

--- a/.claude/skills/retentioneering-contributing/references/repo-conventions.md
+++ b/.claude/skills/retentioneering-contributing/references/repo-conventions.md
@@ -1,0 +1,70 @@
+# Repository conventions (retentioneering-tools, branch v5-migration)
+
+Condensed from AGENTS.md, CONTRIBUTING.md, and docs/adr/ of this checkout. When in
+doubt, those files win; ADR index: `docs/adr/README.md`.
+
+## Commands
+
+```bash
+uv sync                              # python deps incl. dev group (pytest, ruff, pre-commit)
+cd js && npm install                 # only when touching JS (npm workspaces)
+make build                           # build widget.js/widget-static.js into src/retentioneering/static/
+make watch                           # vite --watch for widget UI iteration
+
+uv run pytest tests/ -v              # full suite; single file/test supported
+uv run pre-commit run --all-files    # ruff lint+format, gitleaks, hygiene hooks
+uv run python docs/scripts/render_pages.py          # regen reference docs from docstrings
+uv run python docs/scripts/generate_widget_demos.py # regen static widget demos
+```
+
+## Architecture rules that gate PRs
+
+- **Unified query engine (L1)** — all DuckDB execution goes through the query-engine
+  layer. The old "replacement scan" idiom (bare `duckdb.sql(f"... FROM df")` resolving
+  caller-scope variables; ADR-0002) is SUPERSEDED — do not reintroduce it. User-facing
+  `sql=` parameters still expose the data under the `eventstream` alias.
+- **Eventstream is immutable**: processors return new instances; `stream.df` is a
+  read-only property. Lineage is recorded (`recipe()` / `from_recipe()`) — new processors
+  must serialize into the ops model (see `ops.py`).
+- **Tools vs widgets split** (ADR-0006): headless computation in `tools/`, anywidget
+  wrappers in `widgets/`; every widget has a `<name>_data` twin whose data parameters
+  match the widget's exactly.
+- **Docstring-driven docs** (ADR-0013): the docs site's reference pages render from
+  docstrings — a docs fix is usually a docstring fix + `render_pages.py`. Guide pages
+  live in `docs/guide/*.md`.
+- **Naming** (ADR-0008): one concept, one name — `path_col`, `event_col`,
+  `timestamp_col`, `session_col`, `segment_col`; windows are `start_event`/`end_event`;
+  duration inputs are unit-strings ("30m") or Timedelta, outputs are seconds; processors
+  are verb-first, widgets are nouns; diff sentinel is `"<REST>"`.
+- **Metric schema registry**: metric parse/validate and the JS metric editor's name list
+  are generated from one schema registry — adding a metric means extending the registry,
+  not hand-editing parallel lists.
+
+## Cross-cutting sync obligations (change one → update all in the same PR)
+
+| You changed | Also update |
+|---|---|
+| Any public Eventstream method name/signature | MCP tool layer (`mcp/`), its docstrings, playbook |
+| Metric definitions | schema registry (drives both Python validation and JS editor) |
+| Widget traitlets / data contract | JS side (`js/viz-core`, `js/widget`) — Python traitlets and JS `model.get/set` keys are one protocol |
+| Docstrings of public API | `render_pages.py` regen (commit output if the repo tracks it) |
+| User-visible behavior | `CHANGELOG.md` entry |
+
+## Quality bar
+
+- Tests colocated under `tests/<area>/`; bug fixes ship with the failing-before test.
+- House error style: fail fast and helpful — list valid values/keys in the message
+  (e.g., schema errors name valid keys; metric errors name the required arg). Silent
+  data loss or silent empty results are auto-reject.
+- Determinism: seeded stochastic steps; stable ordering on timestamp ties (ORDER BY
+  timestamp, subindex in aggregations).
+- CI (GitHub Actions): `lint` + `test` matrix on Python 3.11–3.13, builds JS first.
+  `master` is protected: PRs only; release is tag-driven (`v*`), not merge-driven.
+- Telemetry code paths: never send data values — method names/arg names only; any change
+  near `_tracking.py` must preserve this and the documented opt-out.
+
+## Small map of the tree
+
+`src/retentioneering/{eventstream,data_processors,tools,widgets,metrics,mcp,utils}` ·
+`js/{viz-core,widget}` (npm workspaces → build outputs land in `src/.../static/`) ·
+`docs/{guide,adr,scripts}` · `tests/` mirrors `src` areas.

--- a/.claude/skills/retentioneering-product-analytics/SKILL.md
+++ b/.claude/skills/retentioneering-product-analytics/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: retentioneering-product-analytics
+description: >
+  Analyze event logs, clickstreams, user paths, product funnels, retention,
+  behavioral segments, transition graphs, step matrices, sequence patterns,
+  and customer journeys using Retentioneering. Use when the user provides
+  CSV, Parquet, pandas, or database event data containing user, event, and
+  timestamp columns, or asks why users convert, churn, loop, abandon a flow,
+  or follow particular product paths. Do not use for qualitative
+  journey-mapping workshops or aggregate website traffic without user-level
+  event sequences.
+license: Apache-2.0
+compatibility: >
+  Requires Python >= 3.11 and Retentioneering 5.x. Designed for local CSV,
+  Parquet, and pandas event logs. Network access is not required for local
+  analysis.
+metadata:
+  author: retentioneering
+  version: "1.0.0"
+  package: retentioneering
+  category: data-analysis
+  keywords: >-
+    clickstream, event log, user paths, customer journey, product analytics,
+    funnel analysis, retention, churn, behavioral segmentation, transition
+    graph, step matrix, sankey, sequence mining, markov chain, pandas, duckdb
+  homepage: https://retentioneering.com
+  documentation: https://retentioneering.com/docs
+  repository: https://github.com/retentioneering/retentioneering-tools
+---
+
+# Retentioneering product analytics
+
+## Objective
+
+Turn event-level behavioral data into a reproducible answer to a **product question** —
+why users convert, churn, loop, or abandon — using user trajectories, transitions,
+funnels, and behavioral segments.
+
+Do not merely generate visualizations. Connect each output to the question, separate
+observation from interpretation, and never present path correlations as causal effects.
+
+## Bundled references (read on demand, not upfront)
+
+| File | Read it when |
+|---|---|
+| `references/api-map.md` | before writing any Retentioneering call — verified signatures, argument conventions, return shapes for 5.x |
+| `references/analysis-recipes.md` | after the question is clear — 10 field-tested patterns (R1–R10) with skeletons and pitfalls |
+| `references/gotchas-and-validation.md` | before executing (API gotchas G1–G10) and before presenting (integrity checklist B1–B10) |
+| `scripts/inspect_event_log.py` | step 2 — automated data profiling and schema suggestion |
+
+## Required event-log semantics
+
+Minimum: a path identifier (user or session), an event name, a timestamp (or a reliable
+order column — see gotcha G2 for order-only data). Useful extras: session id, segment
+attributes (device, source, plan), event properties, conversion labels.
+
+## Workflow
+
+### 1. Environment
+
+1. Confirm the package: `python -c "import retentioneering; print(retentioneering.__version__)"`.
+   Expect 5.x; this skill's API map is version-verified for 5.0 — on a different major
+   version, trust installed docstrings over the map.
+2. Locate the event data (CSV / Parquet / frames in existing code). Never modify inputs.
+3. Do not invent methods: anything not in `references/api-map.md` must be verified
+   against the installed package before use.
+
+### 2. Inspect the data BEFORE choosing methods
+
+Run `scripts/inspect_event_log.py <path> [--sep ...]` (or replicate its checks inline for
+in-memory frames). It profiles columns, infers the user/event/timestamp mapping, checks
+timestamp parseability, duplicates, per-path ordering, path-length distribution, and
+emits `artifacts/data-profile.json` plus a ready-to-paste `Eventstream(...)` schema.
+
+Report to the user before proceeding: inferred mapping, row/user/event-type counts,
+covered period, and any red flags (nulls in key columns, timestamp ties, suspected bots
+or ultra-long paths, order-only timestamps). Confirm the mapping if inference is
+ambiguous.
+
+### 3. Frame the product question, then pick the SMALLEST recipe
+
+Map the question to a recipe in `references/analysis-recipes.md`:
+navigation structure/loops → transition graph (R1/R6) · before/after an anchor →
+step matrix (R3) · ordered conversion flow → funnel (R1/R2) · what winners do
+differently → diff on a funnel-stage segment (R2) · heterogeneous users → clustering
+without target leakage (R5) · between two funnel levels → truncate micro-journey (R4) ·
+intervention timing → time-to-outcome (R7) · cross-segment scan → segment overview (R8) ·
+value of a fix → Markov what-if (R9, advanced).
+
+Combine recipes only when each addition resolves a distinct uncertainty.
+
+### 4. Execute reproducibly
+
+1. Prefer a rerunnable script (or a notebook executed top-to-bottom) over ad-hoc cells.
+2. Write artifacts to a dedicated output directory (`artifacts/` by default).
+3. Log every filtering rule and its row/path impact; never silently drop data
+   (integrity item B2).
+4. Use `sample_paths(frac=, random_state=)` for stable subsamples; stochastic steps get
+   explicit seeds.
+5. Record lineage: save `processed.recipe()` and the package version into
+   `artifacts/run-metadata.json` — any artifact must be regenerable from raw data via
+   `Eventstream.from_recipe(raw_df, recipe)`.
+
+### 5. Validate before presenting
+
+Work through `references/gotchas-and-validation.md` section B. Non-negotiables:
+every percentage names its denominator; population filters are disclosed with counts;
+survivorship and exposure confounds addressed; no outcome leakage into features;
+small cells flagged with n; caption numbers come from headless `*_data` twins;
+visuals agree with tables.
+
+### 6. Interpret and deliver
+
+Structure the final answer as:
+
+1. **Observed** — numbers with denominators and n.
+2. **Interpretation** — what it likely means.
+3. **Alternative explanations** — selection, structure, censoring.
+4. **Product hypotheses** — each with the metric an experiment would move.
+5. **Suggested next analyses / A-B tests.**
+6. **Limitations.**
+
+Deliverables: analysis script or executed notebook; `artifacts/data-profile.json`;
+`artifacts/metrics.csv` (key tables); interactive HTML exports via
+`widget.export_html(..., title=, analysis=)` — write `analysis=` captions AFTER
+conclusions are final; `artifacts/summary.md` (mapping, filters, assumptions, versions,
+findings, limitations, next steps); `artifacts/run-metadata.json` (versions, parameters,
+seeds, `recipe()` lineage).

--- a/.claude/skills/retentioneering-product-analytics/references/analysis-recipes.md
+++ b/.claude/skills/retentioneering-product-analytics/references/analysis-recipes.md
@@ -1,0 +1,183 @@
+# Analysis recipes
+
+Ten field-tested patterns, each distilled from real product investigations (e-commerce
+checkout, game telemetry at 1.6M events, catalog browsing, navigation-game paths).
+Each recipe: when to use → skeleton → how to read → pitfalls. Pick the SMALLEST recipe
+that answers the question; combine only when each addition resolves a distinct uncertainty.
+
+Skeletons assume `stream` is an `Eventstream` (see `api-map.md`).
+
+---
+
+## R1 · First picture of a product ("what is going on here?")
+
+```python
+d = stream.describe(top_events=None)          # full frequency table, no truncation
+f = stream.funnel_data(steps=[...])           # your best guess of the core flow
+tg = stream.transition_graph(edge_weight="proba_out")
+tg.export_html("artifacts/overview_graph.html", title="...", analysis="...")
+```
+
+Read: `step_conversion_rate` locates the worst cliff; the graph shows where traffic
+actually goes. Pitfalls: start the funnel at a meaningful entry (not the landing page —
+many users enter mid-flow); optional steps (e.g. a review screen only 10% pass) do not
+belong in `steps`.
+
+## R2 · Converted vs dropped ("what do winners do differently?")
+
+The single highest-yield move in the toolkit.
+
+```python
+lab = stream.add_segment("stage", funnel_events=["basket", "checkout", "purchase"])
+lab.transition_graph(diff=("stage", "purchase", "basket"))     # diff = purchase − basket
+lab.step_matrix(path_pattern=".*->basket->.*", diff=("stage", "purchase", "basket"))
+```
+
+Read: positive cells = over-represented among converters. Pitfalls: `funnel_events` is
+closed/ordered — a path that hit `checkout` before ever hitting `basket` is labeled
+`basket`, target-only paths get `out_of_funnel`; check `get_segment_levels()` and group
+sizes before interpreting.
+
+## R3 · Around an anchor event ("what happens right before/after X?")
+
+```python
+(m,) = stream.step_matrix_data(max_steps=6, path_pattern=".*->basket->.*")
+m[[0, 1, 2]]        # column 0 = the anchor itself, 1..n = steps after
+```
+
+Read: rising `path_end` share right after the anchor = the anchor is where paths die.
+Pitfalls: with `path_pattern` the headless return is a tuple of per-anchor blocks —
+unpack; with `diff` it is `(blocks, g1_blocks, g2_blocks)`.
+
+## R4 · Micro-journey between two funnel levels
+
+```python
+micro = stream.truncate_paths(start_event="basket", end_event="checkout")
+micro.transition_graph(edge_weight="proba_out")
+micro.get_metrics([{"metric": "length"}, {"metric": "duration"}]).describe()
+```
+
+Read: what successful walkers actually traverse (detours, loops, help pages) and how
+long the crossing takes (median steps/minutes → timing for recovery nudges).
+Pitfalls: paths lacking either anchor are DROPPED — population = completers only. To
+compare with non-completers, split first (`filter_paths` on `has_event`), truncate each
+population by its own rules, analyze separately.
+
+## R5 · Behavioral segmentation without target leakage
+
+```python
+KEY_FAMILIES = ["listing", "product", "add_to_cart", "search", "promo"]  # NO outcome events!
+FEATURES = (
+    [{"metric": "length"}, {"metric": "duration"}, {"metric": "active_days"}]
+    + [{"metric": "event_count", "metric_args": {"event": e}} for e in KEY_FAMILIES]
+)
+res = stream.cluster_analysis_data(
+    features=FEATURES, n_clusters="3-8",
+    overview_metrics=FEATURES + [
+        {"metric": "has_event", "metric_args": {"event": "purchase"}, "agg": "mean"},
+    ],   # outcome goes HERE, for validation only
+)
+labeled = stream.add_clusters(name="behavior", features=FEATURES,
+                              n_clusters=res["best_params"]["n_clusters"])
+```
+
+Read: conversion spread ACROSS clusters (from overview) is the finding; cluster profiles
+name the personas. Pitfalls: outcome events in `features` produce silhouette≈0.9
+"clusters" that merely restate the funnel — impressive and useless. Inspect the
+silhouette curve yourself: a best-K at the range boundary or a >90/10 split means the
+clustering is weak regardless of `best_params`; on degenerate data `best_params` may be
+absent entirely. Cluster labels are strings (`"cluster_0"`); interpret via top routes and
+sizes, and treat clusters as centroids, not rules.
+
+## R6 · Loops and repeated behavior ("where do users churn in place?")
+
+Self-loops live on the transition-matrix diagonal; A→B→A patterns via `matches_pattern`:
+
+```python
+tm = stream.transition_graph_data(edge_weight="proba_out")
+selfloops = {e: tm.loc[e, e] for e in tm.index}
+pogo = stream.get_metrics([{"metric": "matches_pattern",
+                            "metric_args": {"pattern": "listing->product->listing"}}])
+```
+
+Pitfalls (both are result-killers): (1) count loops BEFORE `collapse_events(consecutive=)`
+— collapsing erases them; (2) naive "conversion of users with loop vs without" is
+confounded by exposure — longer paths have more loops AND more chances to convert;
+stratify by path-length quantiles before comparing.
+
+## R7 · Time-to-outcome and intervention windows
+
+```python
+tb = stream.get_metrics([{"metric": "time_between",
+                          "metric_args": {"start_event": "basket",
+                                          "end_event": "checkout"}}]).dropna()
+# completers' timing; for a survival view add censored paths (reached basket, no checkout)
+```
+
+Read: median/quantiles of completion → after which delay organic completion is <5% —
+that is when a nudge fires. Pitfalls: `time_between` = first A to first B globally in the
+path, not "first B after A" — for strict semantics compute from `to_dataframe()`; account
+for right-censoring near the end of the log window.
+
+## R8 · Compare segments on many metrics at once
+
+```python
+stream.segment_overview(segment_col="device", metrics=[
+    {"metric": "length", "agg": "median"},
+    {"metric": "has_event", "metric_args": {"event": "purchase"}, "agg": "mean"},
+])
+```
+
+Read: scan for the metric with the largest cross-segment gap, then drill with R2/R3.
+Pitfalls: report `n` per segment value alongside every share — a 100% on 5 paths is
+noise; flag small cells explicitly (reviewers will ask).
+
+## R9 · What-if on a Markov chain (advanced; custom math on top)
+
+Estimate the value of removing/rerouting a friction step (e.g., guest checkout):
+
+```python
+counts = sub.transition_graph_data(edge_weight="count").astype(float).fillna(0)
+# build absorbing chain on counts; edit edges (reroute basket->login mass to basket->checkout);
+# recompute absorption; bootstrap paths for CIs
+```
+
+Non-negotiables learned in the field: (1) build the chain on the RELEVANT SUB-POPULATION
+(paths containing the anchor, `truncate_paths` to first anchor→outcome) — a chain over
+the full log averages transition rows over unrelated users and badly distorts absorption;
+(2) validation gate — base-chain absorption must reproduce the observed conversion before
+any scenario is trusted; (3) plug-in absorption equals the training-set rate by
+construction, so the model's value is in scenario DELTAS, not level forecasts;
+(4) rerouted users converting like organic ones is an upper-bound assumption — present a
+sensitivity grid (25/50/100% of the empirical rate).
+
+## R10 · Package results for stakeholders
+
+```python
+w = lab.transition_graph(diff=("stage", "purchase", "basket"))
+w.export_html("artifacts/conv_vs_drop.html", title="...",
+              analysis="Findings in markdown; [basket] and [checkout] become clickable.")
+meta = {"recipe": processed.recipe(), "version": retentioneering.__version__,
+        "filters": "...", "params": {...}}
+```
+
+Rules that survived stakeholder review: write the `analysis=` text AFTER conclusions are
+final (a stale caption contradicting the report is a credibility killer); caption numbers
+must come from the headless twin, not from memory; ship `recipe()` + versions in
+`run-metadata.json` so any artifact is regenerable from raw data.
+
+---
+
+## Choosing quickly
+
+| Question shape | Recipe |
+|---|---|
+| "What's going on / where do we lose people?" | R1 → R2 |
+| "What happens around event X?" | R3 |
+| "What do successful users do between A and B?" | R4 |
+| "What kinds of users do we have?" | R5 |
+| "Why do users go in circles?" | R6 |
+| "When should we intervene?" | R7 |
+| "Which segment behaves differently?" | R8 |
+| "What is fixing X worth?" | R9 |
+| "How do I hand this to a PM?" | R10 |

--- a/.claude/skills/retentioneering-product-analytics/references/api-map.md
+++ b/.claude/skills/retentioneering-product-analytics/references/api-map.md
@@ -1,0 +1,151 @@
+# Retentioneering 5.0 — verified API map
+
+Every signature below was executed against retentioneering 5.0 (branch `v5-migration`,
+July 2026). If your installed version differs, verify before use:
+
+```python
+import retentioneering; print(retentioneering.__version__)
+```
+
+Authoritative per-method reference: docstrings in the installed package and
+https://retentioneering.com/docs. This map exists so you do not have to guess names,
+argument conventions, or return shapes.
+
+## 1. Eventstream — the hub object
+
+```python
+from retentioneering import Eventstream
+
+stream = Eventstream(df, schema={
+    "path_cols":     ["user_id"],            # path identity; nesting allowed: ["user_id","session_id"]
+    "event_cols":    ["event"],
+    "timestamp_col": "timestamp",            # REQUIRED; parseable datetimes (tz-aware OK)
+    "segment_cols":  ["device", "country"],  # categorical labels usable in every diff/overview
+    "custom_cols":   ["price"],              # carried along; visible to sql= modes
+})
+```
+
+- Defaults match columns named `user_id` / `event` / `timestamp` — `Eventstream(df)` just works then.
+- Unknown schema keys raise `SchemaConfigError` listing valid keys (trust this error).
+- Rows with null path values are rejected loudly. Numeric path ids stay numeric
+  (they are NOT cast to str) — join freely with your source frame.
+- `stream.df` is a READ-ONLY property (assignment raises). For a materialized copy use
+  `stream.to_dataframe(exclude_start_end=True)`.
+- Event names may not contain `->` (raises `SchemaConfigError` — it is the path-pattern delimiter).
+- Every processor returns a NEW Eventstream (immutable chaining).
+
+First calls on any new dataset:
+
+```python
+d = stream.describe(top_events=20)      # dict: schema, shape, date_range, event_frequency,
+                                        #       path_stats, segments
+d["event_frequency"].attrs              # {'truncated': True, 'n_total_events': N} when cut;
+                                        # pass top_events=None to disable truncation
+stream.get_event_counts()               # {event: count}
+stream.get_segment_levels()             # {segment_col: [values...]}
+```
+
+## 2. Data processors (verb-first, chainable)
+
+| Processor | Use for | Notes |
+|---|---|---|
+| `filter_events(keep=/drop=/func=/sql=)` | row-level filtering | exactly one mode; `sql=` is full DuckDB over alias `eventstream` (CTEs OK) |
+| `filter_paths(condition)` | keep whole paths by metric condition tree | leaves `{"op","metric","value","metric_args"}`; branches `and/or/not`; top-level list = AND; raises `EmptyEventstreamError` when nothing survives |
+| `add_segment(name, rules=/func=/sql=/funnel_events=)` | add a segment column | `funnel_events` labels each path by the furthest step reached IN ORDER (closed funnel); non-reachers get `"out_of_funnel"` |
+| `add_clusters(name, features, n_clusters, ...)` | materialize clusters as a segment column | labels are strings `"cluster_0"...`; deterministic (seeded) |
+| `add_start_end_events()` | explicit `path_start`/`path_end` rows | idempotent; widgets add them implicitly |
+| `rename_events(mapping)` | collapse taxonomies (e.g. `"PLP: *"` families by explicit dict) | unknown keys raise |
+| `collapse_events(consecutive=True | [...])` | dedupe consecutive repeats | count loops BEFORE collapsing if loops are your subject |
+| `split_sessions(timeout="30m" | separator= | start_event=+end_event=)` | derive sessions | duration strings need units; column params use `session_col` naming |
+| `truncate_paths(start_event, end_event)` | window each path between two events | `path_start`/`path_end` sentinels supported; paths missing either anchor are DROPPED — see gotchas for the keep-whole pattern |
+| `drop_events / drop_segment / edit_events / rename_segment_levels / sample_paths / to_daily_states / urls_to_events / add_events` | as named | `sample_paths(frac=, random_state=)` for stable subsamples |
+
+## 3. Metrics registry — one config format everywhere
+
+Used by `get_metrics(list)`, `filter_paths(condition)`, `cluster_analysis*(features=/overview_metrics=)`,
+`segment_overview(metrics=)`.
+
+```python
+stream.get_metrics([
+    {"metric": "length"},
+    {"metric": "duration"},                                            # seconds
+    {"metric": "event_count",   "metric_args": {"event": "basket"}},   # SINGLE event → key 'event'
+    {"metric": "has_event",     "metric_args": {"event": "purchase"}},
+    {"metric": "has_any_event", "metric_args": {"events": ["a","b"]}}, # LIST → key 'events' (OR)
+    {"metric": "has_all_events","metric_args": {"events": ["a","b"]}}, # LIST → key 'events' (AND)
+    {"metric": "time_between",  "metric_args": {"start_event": "basket",
+                                                "end_event": "purchase"}},
+    {"metric": "matches_pattern","metric_args": {"pattern": "basket->.*->purchase"}},
+])   # -> DataFrame indexed by path id
+```
+
+Argument-key convention (this exact split is version-verified):
+**single event → `event` (string); multiple events → `events` (list) and only on
+`has_any_event` / `has_all_events`.** Wrong keys raise `InvalidMetricConfigError`
+naming the requirement.
+
+Other metrics: `active_days`, `first_event_time`, `in_segment` (modes `any/all/event_share`).
+`matches_pattern` is token-wise (no substring false-positives) and order-deterministic.
+`time_between` measures first occurrence of A to first occurrence of B **globally in the
+path** (not "first B after A") — verify fit for your question.
+
+## 4. Tools: widgets + headless twins
+
+Every widget has a headless `<name>_data(...)` twin returning plain data with the same
+data parameters. Common widget params: `diff=`, `path_col=`, `height=`, `sidebar_open=`,
+`state_file=`.
+
+| Widget | Headless returns | Key params |
+|---|---|---|
+| `transition_graph` | events×events DataFrame | `edge_weight` ∈ `proba_out, proba_in, count, unique_paths, share_of_total, avg_per_path, time_median, time_q95` |
+| `step_matrix` / `step_sankey` | no `path_pattern`: DataFrame; with `path_pattern`: tuple of per-anchor blocks; with pattern+diff: `(blocks, g1_blocks, g2_blocks)` | `max_steps`, `path_pattern=".*->X->.*"` — the anchor event sits at column **0** |
+| `funnel` | dict; each step has `unique_paths`, `conversion_rate` (share of ALL paths) **and `step_conversion_rate`** (step-to-step) | `steps=[...]` — closed/ordered semantics: a path counts at step N only after passing all previous |
+| `segment_overview` | DataFrame metrics×segment values | `metrics=[...]` with `agg` |
+| `cluster_analysis` | dict: `overview_df`, `silhouette` (`{"params": [...], "silhouette": [...]}`), `cluster_labels`, `best_params` | `n_clusters` accepts int, list, or range string `"3-8"`; features = metric configs |
+
+**diff semantics:** `diff=(segment_col, v1, v2)` (also `(path_ids1, path_ids2)`; `v2` may be
+`"<REST>"`). Returned diff block = **value1 − value2**. Segment values must match exactly
+(check `get_segment_levels()`).
+
+## 5. Deliverables: standalone interactive HTML
+
+```python
+w = stream.transition_graph(diff=("device", "mobile", "desktop"))
+w.export_html("artifacts/graph.html",
+              title="Mobile vs desktop",
+              analysis="Markdown text; [event_name] references become clickable node links.")
+```
+
+- `export_html` is a method of the **widget**, not the stream.
+- Files are fully self-contained (~1.2 MB, no CDN) — safe to attach or email.
+- A failed recompute raises `WidgetExportError` (no silent empty exports).
+- Widgets construct headlessly in plain scripts — Jupyter is not required for export.
+
+## 6. Reproducibility: lineage recipes
+
+Processor chains are recorded and replayable:
+
+```python
+processed = stream.filter_events(drop={"event": ["noise"]}).rename_events({"a": "A"})
+rec = processed.recipe()                     # JSON-serializable list of ops
+replayed = Eventstream.from_recipe(raw_df, rec)   # re-applies the same chain
+```
+
+Persist `rec` in run metadata so any artifact can be regenerated from raw data.
+
+## 7. MCP server (agent-driven analysis)
+
+```python
+import retentioneering.mcp as mcp
+mcp.serve()                    # data-agnostic: agent loads an eventstream on demand
+mcp.serve(stream, port=8765)   # or pre-loaded; raises OSError if port is taken
+```
+
+## 8. Environment notes
+
+- Requires Python ≥ 3.11. Backend is an embedded engine (DuckDB family) — millions of rows
+  run in seconds on a laptop; no network needed.
+- Interactive widgets from a *source checkout* need the JS bundle built (`make build`,
+  Node required). pip-installed wheels ship the bundle.
+- Telemetry: the library reports anonymous usage (method names, never data);
+  see the docs "Tracking" page for scope and opt-out.

--- a/.claude/skills/retentioneering-product-analytics/references/gotchas-and-validation.md
+++ b/.claude/skills/retentioneering-product-analytics/references/gotchas-and-validation.md
@@ -1,0 +1,70 @@
+# Gotchas and validation
+
+Two lists with different natures. **API gotchas**: current library behaviors that
+surprise; work around them as described. **Analysis integrity**: methodological traps
+that produced wrong-but-plausible conclusions in real investigations until a reviewer
+caught them; validate against each before shipping numbers.
+
+## A. API gotchas (version-verified)
+
+| # | Behavior | Handle it |
+|---|---|---|
+| G1 | `truncate_paths` DROPS paths missing either anchor; there is no keep-whole option | for "truncate converters, keep the rest whole": `filter_paths` split → truncate the converter half → analyze separately (concatenating streams is manual) |
+| G2 | No order-only mode: `timestamp_col` is mandatory | for logs with click order but no clock: synthesize `base_date + order * 1s`; then durations/`time_median` are MEANINGLESS — never report them, only step counts |
+| G3 | `time_between` = first A to first B **globally**, not first-B-after-A | off-by-few on paths where B precedes A; compute strict semantics via `to_dataframe()` when it matters |
+| G4 | `funnel` is closed/ordered only | for presence-based ("did all of these happen, any order") use `has_all_events` via `get_metrics` |
+| G5 | Metric arg keys: single event → `event`, lists → `events` (only on `has_any_event`/`has_all_events`) | copy from api-map, not from memory; errors are loud and name the requirement |
+| G6 | Cluster result may LACK `best_params` when silhouette is undefined for every candidate (degenerate/duplicate feature rows) | guard `res.get("best_params")`; treat as "no cluster structure" |
+| G7 | Cluster labels are strings `"cluster_0"...`; diff values must match segment levels exactly | check `get_segment_levels()` before writing `diff=(...)` |
+| G8 | Transition matrix may be integer-typed with NaN gaps | before matrix math: `.astype(float).fillna(0)` |
+| G9 | Graph widgets with >~100 nodes open as a dense hairball | teach the edge-weight threshold in the sidebar; or pre-aggregate events into families (`rename_events`) |
+| G10 | `stream.df` is read-only | mutate via processors; materialize with `to_dataframe()` |
+
+Fixed in 5.0 — do NOT carry these legacy workarounds forward: identifier quoting for
+SQL-reserved column names; nondeterministic `matches_pattern` ordering; `n_clusters`
+range strings; silent `describe()` truncation (now flagged in `.attrs`, disable with
+`top_events=None`); silent empty widget exports (now `WidgetExportError`); substring
+pattern matching; anchor off-by-one in step matrix; `diff` sign (now v1−v2).
+
+## B. Analysis integrity checklist
+
+Run before presenting conclusions. Each item traces to a real wrong-conclusion incident.
+
+1. **Denominators.** Every percentage names its base. `funnel_data.conversion_rate` is
+   share of ALL paths; step-to-step is `step_conversion_rate`. *(Incident: "2% conversion"
+   nearly shipped where the true step rate was 32%.)*
+2. **Population.** Who exactly is in the analysis? Watch entry filters (`truncate_paths`
+   drops non-completers, G1) and "engaged users only" thresholds. *(Incident: a ≥10-min
+   activity cutoff silently excluded 43% — the weakest users, the ones the decision was
+   about; on the full cohort the verdict got harsher, not softer.)*
+3. **Survivorship.** Late-stage aggregates describe survivors. Report "of all who
+   started / of those who reached" side by side. Ratings/feedback exist only for
+   finishers.
+4. **Exposure confound.** Longer paths contain more of everything (loops, feature
+   touches) AND convert more. Any "users who did X convert better" claim needs
+   stratification by path length or a matched design.
+5. **Target leakage.** No outcome events in clustering features (R5) or in
+   sequence/pattern features computed over the full path — cut paths at the first
+   outcome before mining predictive patterns.
+6. **Structural vs behavioral lift.** If the flow FORCES step A before outcome B, "users
+   who did A convert ×100" is architecture, not behavior. Say which one you measured.
+7. **Small cells.** Shares without `n` are noise bait; flag cells with n below ~30 and
+   add intervals (Wilson for proportions) when a decision hangs on them.
+8. **Right/left censoring.** Log windows cut both ends: "never returned" near the window
+   edge and "first session" of users active before the window are both suspect.
+9. **Correlation discipline.** Observational path data supports "associated with", not
+   "drives", unless there is an experiment. End reports with hypotheses + suggested A/B,
+   not causal claims.
+10. **Numbers ↔ visuals.** Every caption number comes from the headless twin of the
+    widget shown; write `analysis=` texts after conclusions are frozen.
+
+## C. Self-checks worth automating
+
+```python
+# conservation: filters explain themselves
+before = stream.describe()["shape"]; after = filtered.describe()["shape"]
+# funnel sanity: step counts are non-increasing
+# diff sanity: diff block equals g1 - g2 on a sample cell
+# determinism: rerun the pipeline; assert identical key outputs
+# reproducibility: Eventstream.from_recipe(raw_df, processed.recipe()) equals processed
+```

--- a/.claude/skills/retentioneering-product-analytics/scripts/inspect_event_log.py
+++ b/.claude/skills/retentioneering-product-analytics/scripts/inspect_event_log.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python
+"""Profile an event log and suggest a Retentioneering Eventstream schema.
+
+Usage:
+    python inspect_event_log.py PATH [--sep SEP] [--user-col C] [--event-col C]
+                                [--ts-col C] [--sample-rows N] [--out DIR]
+
+Reads CSV/TSV/Parquet, infers user/event/timestamp columns when not given,
+runs data-quality checks, writes artifacts/data-profile.json, and prints a
+human report plus a ready-to-paste Eventstream(...) snippet.
+
+Only requires pandas. If retentioneering is importable, its version is recorded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+import pandas as pd
+
+USER_HINTS = (
+    "user_id",
+    "user",
+    "client_id",
+    "customer_id",
+    "uid",
+    "session_id",
+    "hashed",
+    "player",
+    "visitor",
+)
+EVENT_HINTS = ("event_name", "event", "action", "event_type_name", "page", "screen")
+TS_HINTS = ("timestamp", "event_time", "time", "datetime", "ts", "date")
+SEGMENT_HINTS = (
+    "device",
+    "platform",
+    "country",
+    "source",
+    "utm",
+    "channel",
+    "plan",
+    "os",
+    "browser",
+    "campaign",
+    "medium",
+    "group_name",
+    "variant",
+)
+
+
+def sniff_sep(path: str) -> str:
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        head = fh.readline()
+    for sep in ("\t", ";", ",", "|"):
+        if head.count(sep) >= 2:
+            return sep
+    return ","
+
+
+def pick(columns, hints, taken):
+    lowered = {c.lower(): c for c in columns}
+    for h in hints:
+        for lc, orig in lowered.items():
+            if h == lc and orig not in taken:
+                return orig
+    for h in hints:
+        for lc, orig in lowered.items():
+            if h in lc and orig not in taken:
+                return orig
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("path")
+    ap.add_argument("--sep", default=None)
+    ap.add_argument("--user-col", default=None)
+    ap.add_argument("--event-col", default=None)
+    ap.add_argument("--ts-col", default=None)
+    ap.add_argument(
+        "--sample-rows",
+        type=int,
+        default=None,
+        help="read only the first N rows (for very large files)",
+    )
+    ap.add_argument("--out", default="artifacts")
+    a = ap.parse_args()
+
+    if a.path.endswith((".parquet", ".pq")):
+        df = pd.read_parquet(a.path)
+        sep = None
+    else:
+        sep = a.sep or sniff_sep(a.path)
+        df = pd.read_csv(a.path, sep=sep, nrows=a.sample_rows, low_memory=False)
+
+    cols = list(df.columns)
+    taken: set = set()
+    user_col = a.user_col or pick(cols, USER_HINTS, taken)
+    taken.add(user_col)
+    event_col = a.event_col or pick(cols, EVENT_HINTS, taken)
+    taken.add(event_col)
+    ts_col = a.ts_col or pick(cols, TS_HINTS, taken)
+    taken.add(ts_col)
+    segment_cols = [
+        c
+        for c in cols
+        if c not in taken
+        and any(h in c.lower() for h in SEGMENT_HINTS)
+        and df[c].nunique(dropna=True) <= max(50, len(df) // 100)
+    ]
+
+    problems: list[str] = []
+    if not user_col or not event_col:
+        problems.append(
+            "could not infer user/event columns — pass --user-col/--event-col"
+        )
+
+    profile: dict = {
+        "path": os.path.abspath(a.path),
+        "sep": sep,
+        "rows_read": int(len(df)),
+        "sampled": a.sample_rows is not None,
+        "columns": cols,
+        "inferred": {
+            "user_col": user_col,
+            "event_col": event_col,
+            "ts_col": ts_col,
+            "segment_candidates": segment_cols,
+        },
+    }
+
+    if user_col and event_col:
+        nulls_user = int(df[user_col].isna().sum())
+        nulls_event = int(df[event_col].isna().sum())
+        profile["n_paths"] = int(df[user_col].nunique(dropna=True))
+        profile["n_event_types"] = int(df[event_col].nunique(dropna=True))
+        profile["nulls"] = {"user": nulls_user, "event": nulls_event}
+        if nulls_user:
+            problems.append(
+                f"{nulls_user} rows with null {user_col} — Eventstream will "
+                "reject them; decide drop/repair explicitly"
+            )
+        top = df[event_col].value_counts()
+        profile["top_events"] = {str(k): int(v) for k, v in top.head(25).items()}
+        share = float(top.iloc[0]) / max(len(df), 1)
+        if share > 0.30:
+            problems.append(
+                f"event '{top.index[0]}' is {share:.0%} of all rows — likely "
+                "noise (heartbeat/dialogue); consider drop_events before path tools"
+            )
+        plen = df.groupby(user_col, dropna=True).size()
+        profile["path_length"] = {
+            q: float(plen.quantile(x))
+            for q, x in [("p50", 0.5), ("p90", 0.9), ("p99", 0.99)]
+        } | {"max": int(plen.max()), "n_len1": int((plen == 1).sum())}
+        if plen.max() > 50 * max(plen.median(), 1):
+            problems.append(
+                f"max path length {plen.max()} vs median {plen.median():.0f} "
+                "— check bots/shared accounts"
+            )
+
+    ts_ok = False
+    if ts_col:
+        parsed = pd.to_datetime(df[ts_col], errors="coerce", utc=True, format="mixed")
+        bad = int(parsed.isna().sum())
+        ts_ok = bad == 0
+        profile["timestamp"] = {
+            "unparseable": bad,
+            "min": str(parsed.min()),
+            "max": str(parsed.max()),
+        }
+        if bad:
+            problems.append(f"{bad} unparseable timestamps in {ts_col}")
+        if user_col:
+            ties = int(df.assign(_p=parsed).duplicated([user_col, "_p"]).sum())
+            profile["timestamp"]["within_path_ties"] = ties
+            if ties:
+                problems.append(
+                    f"{ties} same-timestamp ties within paths — ensure a "
+                    "stable secondary order (row order is preserved)"
+                )
+        dup = int(df.duplicated([c for c in (user_col, event_col, ts_col) if c]).sum())
+        profile["exact_duplicates"] = dup
+        if dup:
+            problems.append(
+                f"{dup} exact duplicate (user,event,ts) rows — dedupe or justify"
+            )
+    else:
+        problems.append(
+            "no timestamp column found — if only an order column exists, "
+            "synthesize base_date + order*1s and NEVER report durations (gotcha G2)"
+        )
+
+    try:
+        import retentioneering
+
+        profile["retentioneering_version"] = retentioneering.__version__
+    except Exception:
+        profile["retentioneering_version"] = None
+        problems.append("retentioneering not importable in this environment")
+
+    profile["problems"] = problems
+
+    os.makedirs(a.out, exist_ok=True)
+    out_path = os.path.join(a.out, "data-profile.json")
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump(profile, fh, indent=2, ensure_ascii=False, default=str)
+
+    print(
+        f"rows={profile['rows_read']:,}  paths={profile.get('n_paths', '?'):,}  "
+        f"event_types={profile.get('n_event_types', '?')}"
+    )
+    if ts_col and "timestamp" in profile:
+        print(f"period: {profile['timestamp']['min']} .. {profile['timestamp']['max']}")
+    print(
+        f"inferred: user={user_col}  event={event_col}  ts={ts_col}  "
+        f"segments={segment_cols}"
+    )
+    for p in problems:
+        print(f"  ⚠ {p}")
+    print(f"\nprofile written: {out_path}\n")
+    print("suggested schema:\n")
+    seg = ", ".join(f'"{c}"' for c in segment_cols)
+    print(f"""from retentioneering import Eventstream
+stream = Eventstream(df, schema={{
+    "path_cols": ["{user_col}"],
+    "event_cols": ["{event_col}"],
+    "timestamp_col": "{ts_col}",
+    "segment_cols": [{seg}],
+}})
+stream.describe()""")
+    return 1 if (not user_col or not event_col or not ts_ok) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Thanks for contributing to retentioneering! Keep the PR focused on one logical change. -->
+
+## What & why
+
+<!-- One to three sentences. Link the issue this addresses: Fixes #NNN -->
+
+## Before / after
+
+<!-- For a bug fix: a minimal repro and the behavior before vs after.
+     For a feature: the use case and the new usage. -->
+
+## Checklist
+
+- [ ] Ran `make install` (or `uv run pre-commit install`) so the git hook is active
+- [ ] `uv run pre-commit run --all-files` passes (ruff lint + format, hygiene, gitleaks) — this is CI's `lint` job
+- [ ] `uv run pytest tests/ -q` passes
+- [ ] Added/updated tests (a bug fix includes the failing-before test)
+- [ ] Docstrings updated and, if they changed, `uv run python docs/scripts/render_pages.py` re-run
+- [ ] Sync obligations handled where applicable (MCP tool layer, JS metric editor / widget contract, `CHANGELOG.md`)
+
+## Breaking changes
+
+<!-- None, or describe them plus a migration note. Note: PRs target `master`; releases are tag-driven. -->

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ docs/build/
 # Editors / OS
 .vscode
 .idea/
-.claude/
+.claude/*
+!.claude/skills/
 typings
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,3 +175,13 @@ source of truth — change the docstring, re-render, done.
 No dynamic versioning — `pyproject.toml`'s `version = "..."` is the literal source of truth for
 what gets built and published; it is not derived from git tags. Bumping the git tag alone does
 not change what version the built package identifies as.
+
+## Agent skills
+
+Task-oriented skill packages live in `.agents/skills/` (see its README for the index and
+consumption notes) with an identical copy under `.claude/skills/` for Claude Code's
+native skill loader. Two skills ship today: `retentioneering-product-analytics`
+(event-log analysis workflow: inspect → recipe → execute → validate → interpret) and
+`retentioneering-contributing` (turning findings into issues/PRs that match this
+repository's conventions). When public API changes, re-verify the version-checked claims
+in each skill's `references/api-map.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,15 @@ git clone https://github.com/retentioneering/retentioneering-tools.git
 cd retentioneering-tools
 
 make install     # = uv sync (Python deps incl. dev group) + npm install in js/
+                 #   + pre-commit install (git hook that runs ruff/gitleaks/hygiene on every commit)
 make build       # build the widget JS bundles into src/retentioneering/static/
-
-uv run pre-commit install   # one-time; runs ruff/gitleaks/hygiene hooks on every commit
 ```
+
+`make install` wires up the pre-commit git hook for you, so your commits are
+auto-checked. If you set up the environment without `make install`, run
+`uv run pre-commit install` once yourself — otherwise commits skip the hooks
+locally and CI's `lint` job (which runs `pre-commit run --all-files`) will flag
+the formatting on your PR instead.
 
 `make build` matters more than it looks: the JS bundles (`widget.js`,
 `widget-static.js`) are **gitignored** and built from source — without them,

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 install:
 	uv sync
 	cd js && npm install
+	uv run pre-commit install
 
 build: build-viz build-widget
 


### PR DESCRIPTION
## What & why

Adds two task-oriented **agent skill packages** so coding agents (Claude Code, Codex, and
compatible tools) can drive Retentioneering competently out of the box, and so the packages are
discoverable by skill marketplaces (SKILL.md spec-compliant; validated with `skills-ref`).

- **`retentioneering-product-analytics`** — the full event-log analysis workflow
  (inspect → pick recipe → execute reproducibly → validate → interpret), distilled from an
  extensive test campaign against 5.0. Bundles: a version-verified `api-map.md`, ten
  field-tested `analysis-recipes.md` (funnels, diff, step matrix, segmentation, loops,
  time-to-outcome, Markov what-if, …), a `gotchas-and-validation.md` (current API gotchas +
  an analysis-integrity checklist covering denominators, survivorship, exposure confound,
  target leakage), and an executable `scripts/inspect_event_log.py` profiler.
- **`retentioneering-contributing`** — turning findings into issues/PRs that match this
  repo's conventions: capture → validate-against-current-version → minimal repro → issue/PR,
  with proposal templates and a condensed `repo-conventions.md`.

## Layout

- `.agents/skills/**` — tracked copy for Codex and generic loaders, with an index README.
- `.claude/skills/**` — identical copy for Claude Code's native project-skills loader.
  `.gitignore` is adjusted to **track `.claude/skills/` while keeping local `.claude`
  settings ignored** (`.claude/*` + `!.claude/skills/`).
- `AGENTS.md` gains a short "Agent skills" pointer.

## Verification

- Every method/metric name in `api-map.md` was executed against retentioneering 5.0
  (branch `v5-migration`); a symbol sweep confirms all exist in the package.
- `inspect_event_log.py` and recipes R1/R2/R5/R10 were run end-to-end on real datasets with
  ground-truth assertions (funnel counts, `diff == g1 − g2`, range-string clustering,
  `export_html`, `recipe()` round-trip) — all green.
- Both skills pass `agentskills/skills-ref validate`; `name` matches directory; frontmatter
  within spec limits.

## Notes

- No library code changed — docs/tooling only; no runtime dependency added
  (`inspect_event_log.py` uses stdlib + pandas).
- Skill `references/api-map.md` carries a re-verification note for when the public API changes.

## Breaking changes

None.

---

## Contributor experience (folded in)

Reduces a recurring stumble: contributors who set up without `pre-commit install`
commit unformatted code, and CI's `lint` job (`pre-commit run --all-files`) fails the PR.

- **`make install`** now also runs `uv run pre-commit install`, so the documented setup
  path wires the git hook automatically.
- **`CONTRIBUTING.md`** setup block updated to match, with a note that CI's `lint` job is the
  backstop if the hook was skipped.
- **`.github/PULL_REQUEST_TEMPLATE.md`** added — a short checklist (pre-commit passes, tests
  pass, docstrings/render, sync obligations).
- The **`retentioneering-contributing`** skill's Stage 5 now names `pre-commit install` explicitly.
