### PR TITLE
Decouple pre-commit hook install from `make install`

### DIFF
--- a/.agents/skills/retentioneering-contributing/SKILL.md
+++ b/.agents/skills/retentioneering-contributing/SKILL.md
@@ -99,11 +99,10 @@ For API proposals, the accepted framing (from templates): problem → evidence o
 Read `references/repo-conventions.md` first. Non-negotiables:
 
 1. Fork or branch from `master`-tracking `v5-migration`; one logical change per PR.
-2. `make install` (= `uv sync` + `npm install` + **`pre-commit install`** — the last one wires
-   the git hook so commits are auto-checked). If you skip `make install`, run
-   `uv run pre-commit install` yourself before the first commit — otherwise commits bypass the
-   hooks locally and CI's `lint` job flags the formatting on your PR. Add `make build` only when
-   touching widgets/JS.
+2. `uv sync` (or `make install`, which also runs `npm install`), then **`uv run pre-commit
+   install`** — a one-time-per-clone step that wires the git hook so commits are auto-checked;
+   skip it and commits bypass the hooks locally and CI's `lint` job flags the formatting on your
+   PR. Add `make build` only when touching widgets/JS.
 3. Follow naming conventions (ADR-0008): `path_col/event_col/timestamp_col/session_col`,
    `start_event/end_event`, verb-first processors, noun widgets, `<widget>_data` twins.
 4. All DuckDB execution goes through the unified query engine (L1) — no ad-hoc

--- a/.claude/skills/retentioneering-contributing/SKILL.md
+++ b/.claude/skills/retentioneering-contributing/SKILL.md
@@ -99,11 +99,10 @@ For API proposals, the accepted framing (from templates): problem → evidence o
 Read `references/repo-conventions.md` first. Non-negotiables:
 
 1. Fork or branch from `master`-tracking `v5-migration`; one logical change per PR.
-2. `make install` (= `uv sync` + `npm install` + **`pre-commit install`** — the last one wires
-   the git hook so commits are auto-checked). If you skip `make install`, run
-   `uv run pre-commit install` yourself before the first commit — otherwise commits bypass the
-   hooks locally and CI's `lint` job flags the formatting on your PR. Add `make build` only when
-   touching widgets/JS.
+2. `uv sync` (or `make install`, which also runs `npm install`), then **`uv run pre-commit
+   install`** — a one-time-per-clone step that wires the git hook so commits are auto-checked;
+   skip it and commits bypass the hooks locally and CI's `lint` job flags the formatting on your
+   PR. Add `make build` only when touching widgets/JS.
 3. Follow naming conventions (ADR-0008): `path_col/event_col/timestamp_col/session_col`,
    `start_event/end_event`, verb-first processors, noun widgets, `<widget>_data` twins.
 4. All DuckDB execution goes through the unified query engine (L1) — no ad-hoc

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 
 ## Checklist
 
-- [ ] Ran `make install` (or `uv run pre-commit install`) so the git hook is active
+- [ ] Ran `uv run pre-commit install` (one-time per clone) so the git hook is active
 - [ ] `uv run pre-commit run --all-files` passes (ruff lint + format, hygiene, gitleaks) — this is CI's `lint` job
 - [ ] `uv run pytest tests/ -q` passes
 - [ ] Added/updated tests (a bug fix includes the failing-before test)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,15 +25,16 @@ git clone https://github.com/retentioneering/retentioneering-tools.git
 cd retentioneering-tools
 
 make install     # = uv sync (Python deps incl. dev group) + npm install in js/
-                 #   + pre-commit install (git hook that runs ruff/gitleaks/hygiene on every commit)
 make build       # build the widget JS bundles into src/retentioneering/static/
+
+uv run pre-commit install   # one-time; installs the git hook that runs
+                            # ruff/gitleaks/hygiene on every commit
 ```
 
-`make install` wires up the pre-commit git hook for you, so your commits are
-auto-checked. If you set up the environment without `make install`, run
-`uv run pre-commit install` once yourself — otherwise commits skip the hooks
-locally and CI's `lint` job (which runs `pre-commit run --all-files`) will flag
-the formatting on your PR instead.
+`pre-commit install` is a one-time step per clone (git hooks live in local
+`.git/hooks/` and never travel with a clone). Skip it and your commits bypass
+the hooks locally — CI's `lint` job (which runs `pre-commit run --all-files`)
+then flags the formatting on your PR instead.
 
 `make build` matters more than it looks: the JS bundles (`widget.js`,
 `widget-static.js`) are **gitignored** and built from source — without them,

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 install:
 	uv sync
 	cd js && npm install
-	uv run pre-commit install
 
 build: build-viz build-widget
 


### PR DESCRIPTION
## What & why

Follow-up to #73. Adding `uv run pre-commit install` to the `make install` target coupled the
base dev setup to the pre-commit hook and changed what `make install` means. This reverts that
one line and makes wiring the git hook an explicit, documented one-time step again.

## Changes

- **`Makefile`**: `install` is back to `uv sync` + `npm install` only — no hook wiring.
- **`CONTRIBUTING.md`**: restores the standalone `uv run pre-commit install` step, with a short
  note on *why* it's per-clone (git hooks live in local `.git/hooks/` and never travel with a
  clone) and that CI's `lint` job is the backstop if it's skipped.
- **`.github/PULL_REQUEST_TEMPLATE.md`**: the checklist item points to `uv run pre-commit install`.
- **`retentioneering-contributing` skill** (both copies): Stage 5 names the explicit
  hook-install step instead of implying `make install` performs it.

## Notes

Docs/skill only; no code or Makefile behavior beyond dropping the extra install step.
The `lint` CI job (`pre-commit run --all-files`) remains the server-side guarantee.

## Breaking changes

None.
