### PR TITLE
Fix check_analysis: one link shouldn't validate multiple numbers

### DIFF
--- a/src/retentioneering/mcp/_agent_logic.py
+++ b/src/retentioneering/mcp/_agent_logic.py
@@ -228,6 +228,8 @@ def _find_unlinked_numbers(analysis: str) -> list[dict]:
 
     Rules:
     - A number is OK if a [tab:ref] link appears within 200 chars on the same line.
+      Numbers and links are matched one-to-one, nearest pair first — a link already
+      claimed by a closer number can't also cover a farther, unrelated one.
     - Numbers inside backtick code spans `like 2.2×` are exempt (agent-computed).
     - Lines inside fenced code blocks are skipped.
     - Horizontal rules (---) are skipped.
@@ -292,13 +294,28 @@ def _find_unlinked_numbers(analysis: str) -> list[dict]:
                     }
                 )
 
-        # Check each percentage / multiplier individually
-        for m in re.finditer(
-            r"\d+[.,]?\d*\s*%|\d+[.,]?\d*\s*×|×\s*\d+\.?\d*", s_no_code
-        ):
-            pos = m.start()
-            nearby = any(abs(lp - pos) <= 200 for lp in link_positions)
-            if not nearby:
+        # Pair each percentage / multiplier with its nearest not-yet-claimed
+        # link (within 200 chars), nearest pair first, so one link can't
+        # validate several numbers scattered across the same line.
+        number_matches = list(
+            re.finditer(r"\d+[.,]?\d*\s*%|\d+[.,]?\d*\s*×|×\s*\d+\.?\d*", s_no_code)
+        )
+        candidate_pairs = sorted(
+            (abs(lp - m.start()), i, lp)
+            for i, m in enumerate(number_matches)
+            for lp in link_positions
+            if abs(lp - m.start()) <= 200
+        )
+        claimed_links: set[int] = set()
+        linked_numbers: set[int] = set()
+        for _, i, lp in candidate_pairs:
+            if i in linked_numbers or lp in claimed_links:
+                continue
+            linked_numbers.add(i)
+            claimed_links.add(lp)
+
+        for i, m in enumerate(number_matches):
+            if i not in linked_numbers:
                 issues.append(
                     {
                         "line": lineno,

--- a/tests/mcp/tools_test.py
+++ b/tests/mcp/tools_test.py
@@ -191,6 +191,17 @@ class TestCheckAnalysis:
         assert result["status"] == "needs_fixes"
         assert result["issues"]
 
+    def test__needs_fixes_when_one_link_shares_line_with_two_numbers(self) -> None:
+        # A link near 38% must not also validate the unrelated, unlinked 999%
+        # just because both sit within the 200-char proximity window.
+        result = tools.check_analysis(
+            "Real conversion is 38% [Flow:purchase], invented value is 999%."
+        )
+
+        assert result["status"] == "needs_fixes"
+        assert any(issue["number"] == "999%" for issue in result["issues"])
+        assert all(issue["number"] != "38%" for issue in result["issues"])
+
 
 class TestAddWidgetsAndExportReport:
     def test__export_report_without_tabs_is_an_error(self) -> None:


### PR DESCRIPTION
## Summary
- `_find_unlinked_numbers()` treated any `[tab:ref]` link within 200 chars of a
  number as validating it, so a single link could silently cover every
  percentage/multiplier on the line — even ones it wasn't actually next to.
- Numbers and links are now matched one-to-one: all (number, link) pairs within
  200 chars are sorted by distance and assigned nearest-pair-first, so a link
  already claimed by a closer number can't also validate a farther, unrelated one.
- Docstring updated to match the (now correct) behavior it already documented.

Fixes #87