### PR TITLE
Add an agent-facing docs surface: llms.txt, llms-full.txt, docs MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ per-session state in `mcp/_report_session.py`'s `ReportSession`, and the system 
 API rename must be propagated to `_apply_preprocessors`, the tool docstrings, and the playbook
 in the same change.
 
-### Docs pipeline (ADR-0013)
+### Docs pipeline (ADR-0013, ADR-0014)
 
 Reference pages are rendered from `Eventstream` docstrings (`docs/scripts/render_pages.py` +
 `docs/templates/*.jinja`); hand-written guides live in `docs/guide/`; widget demos are generated
@@ -152,6 +152,13 @@ belongs in the template's `{% block how_it_works %}`, not in the docstring, whic
 short for `help()` and MCP. Figures are hand-written SVG in `docs/img/`, copied to
 `docs/build/demos/img/` and referenced as `/docs-demos/img/*.svg`; style them with plain CSS
 classes plus a `prefers-color-scheme` block, never CSS custom properties (ADR-0013).
+
+The same pass also writes `docs/build/llms.txt` and `docs/build/llms-full.txt` (ADR-0014) — the
+agent-facing copy of the docs, served at the site root and consumed by the documentation MCP
+server at `retentioneering.com/docs/mcp` (which lives in retentioneering-web, not here). A new
+page under `docs/guide/` must be added to the `GUIDES` list in `render_pages.py` or the build
+fails; note that `/docs/mcp` is that endpoint, while the *guide about* the library's own MCP
+server is `/docs/mcp-server`.
 
 ### CI/CD (ADR-0011)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- Docs: `render_pages.py` now also writes `llms.txt` (annotated table of contents, per the [llms.txt convention](https://llmstxt.org)) and `llms-full.txt` (the whole documentation as one ~200 KB file), served at `retentioneering.com/llms.txt` and `/llms-full.txt`. Descriptions are each page's own opening sentence; a guide page missing from the new `GUIDES` order list fails the build (ADR-0014)
+- Docs: a documentation MCP server at `https://retentioneering.com/docs/mcp` — hosted, stateless, no installation, with `search_docs` / `get_doc_page` / `list_doc_pages`. Distinct from the library's own `rete.mcp.serve()`, which is local and works on your data; the [MCP Server](https://retentioneering.com/docs/mcp-server) guide explains the split. Implementation lives in retentioneering-web (ADR-0014)
+
+### Changed
+
+- Docs: the MCP server guide moved from `/docs/mcp` to `/docs/mcp-server` (`docs/guide/mcp.md` → `docs/guide/mcp-server.md`), reserving `/docs/mcp` for a future documentation MCP endpoint. All in-repo links were updated; the old URL is not redirected — it 404s until the endpoint lands there
+- `docs/scripts/render_pages.py`: `copy_guide_pages()` now wipes `docs/build/guide/` before copying, so a renamed or deleted guide page no longer lingers in the build output
+
 ### Fixed
 
 - Cluster Analysis widget: selecting **Standard** feature scaling in the sidebar raised `ValueError: Unknown scaler: std` — the sidebar sends `"std"` while the Python side only accepted `"standard"`. `"std"` is now the canonical spelling on both sides; `"standard"` is still accepted as a legacy alias, so code written against 5.1.0 and earlier keeps working

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ funnel = stream.funnel_data(steps=["catalog", "add_to_cart", "purchase"])  # dic
 - **[Path metrics](https://retentioneering.com/docs/path-metrics)** — one
   registry of per-path metrics that feeds behavioral clustering, segment
   comparison, path filtering, and your own ML feature pipelines.
-- **[MCP server](https://retentioneering.com/docs/mcp)** — exposes the eventstream to Claude or
+- **[MCP server](https://retentioneering.com/docs/mcp-server)** — exposes the eventstream to Claude or
   any MCP client: agents explore the data, build report tabs, and export a
   validated interactive HTML report where every number links to its source.
 

--- a/docs/adr/0014-agent-facing-docs-surface.md
+++ b/docs/adr/0014-agent-facing-docs-surface.md
@@ -1,0 +1,71 @@
+# ADR-0014: Agent-facing documentation surface
+
+Status: Accepted (recorded 2026-07)
+
+## Context
+
+ADR-0013 made docstrings the source of truth for reference docs and pushed
+conceptual depth — mental model, toy examples, figures, pitfalls — out of the
+docstring and into the page template, so `help()` and the MCP tool listing stay
+short. That trade has a consequence nobody had to pay until agents started
+writing retentioneering code: the conceptual layer exists **only** on the docs
+site. An agent using the library's own MCP server (ADR-0009) sees the short
+docstrings and nothing else, and an agent that has not installed the library at
+all sees whatever it remembers — which is 3.x, since that is what the public
+internet is full of (ADR-0012 lists what no longer exists).
+
+The docs are also small: 37 pages, ~200 KB of markdown, roughly 50k tokens for
+the entire corpus. That number decides the design more than anything else.
+
+## Decision
+
+- **Two plain-text artifacts, generated with the rest of the build.**
+  `render_pages.py` writes `docs/build/llms.txt` (annotated table of contents,
+  per [llmstxt.org](https://llmstxt.org)) and `docs/build/llms-full.txt` (the
+  whole corpus in one file). They are build output like every other page — the
+  descriptions in `llms.txt` are each page's own opening sentence, and
+  `GUIDE_DESCRIPTIONS` overrides only the pages that open on a heading or a
+  hook. A guide page missing from the `GUIDES` order list fails the build
+  rather than silently vanishing from the index.
+- **`llms-full.txt` is the corpus, and everything downstream reads it** rather
+  than re-walking `docs/build/`. Site-relative links become absolute, and
+  `<DemoWidget>` tags — a live widget on the site, meaningless to a reader —
+  are replaced by the python they run. One artifact, so the site, the text
+  files and the MCP server cannot disagree about what a page says.
+- **A documentation MCP server at `https://retentioneering.com/docs/mcp`**,
+  implemented in retentioneering-web (`app/docs/mcp/route.ts`), stateless and
+  unauthenticated because it only ever serves public text. Three read-only
+  tools: `search_docs`, `get_doc_page`, `list_doc_pages`. It is distinct from
+  the library's own MCP server (ADR-0009), which is local, needs a kernel and
+  operates on the user's data; the guide page at `/docs/mcp-server` explains
+  the split. The `/docs/mcp` path was freed for it — the guide that used to
+  live there moved, with no redirect left behind.
+- **Search is lexical, not semantic.** Term frequency with field boosts over
+  sections split at `##`. At 37 pages of one library's vocabulary, a query is
+  almost always a method or concept name that appears literally in the text;
+  embeddings would add an index to build, a model to call and non-determinism,
+  for recall we do not need.
+- **Streamable HTTP is implemented directly**, not through a transport
+  library. `@modelcontextprotocol/sdk`'s server transport is built on Node's
+  `req`/`res`, which App Router route handlers do not have, and the npm package
+  named `mcp-handler` is not the Vercel adapter it appears to be. For three
+  read-only tools the protocol surface is `initialize` + `tools/list` +
+  `tools/call`.
+
+## Consequences
+
+- Adding a guide page means adding it to `GUIDES` in `render_pages.py` — the
+  build says so if you forget.
+- Every docs page is prerendered, so their content reads happen at build time;
+  `/docs/mcp` is the one route that reads `content/docs/` at **runtime**, and
+  needs `outputFileTracingIncludes` in `next.config.ts` to have the file in its
+  deployment at all. Without it the route deploys fine and every tool call
+  comes back empty.
+- The section anchors in search results are produced by re-implementing
+  github-slugger's rules; they match because our headings are plain prose.
+  A heading with unusual punctuation could yield a link that lands on the
+  right page but not the right section.
+- Because the corpus fits in a context window, `llms-full.txt` and the MCP
+  server are genuinely alternative front doors rather than a fallback and a
+  real answer. If the docs grow several times over, that stops being true and
+  the search tool becomes the primary path.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,7 @@ here; load individual ADRs when a task touches the corresponding area.
 | [0011](0011-versioning-and-release.md) | Literal versioning, tag-driven release | pyproject version is the source of truth; only `v*` tags publish |
 | [0012](0012-features-dropped-from-3x.md) | Features deliberately dropped from 3.x | Preprocessing Graph, Cohorts, StatTests, Sequences — cut, may return |
 | [0013](0013-docstring-driven-docs.md) | Docstring-driven documentation | reference docs are rendered from docstrings; docstrings are the source of truth |
+| [0014](0014-agent-facing-docs-surface.md) | Agent-facing docs surface | llms.txt / llms-full.txt are build output; a hosted docs MCP server reads the same corpus |
 
 ## Adding a new ADR
 

--- a/docs/guide/agent-skills.md
+++ b/docs/guide/agent-skills.md
@@ -2,7 +2,7 @@
 
 retentioneering ships two Agent Skills — task-oriented instruction packages that coding agents (Claude Code, Codex, Cursor, and other compatible tools) load automatically when a task matches, so the agent follows a tested workflow instead of improvising one from scratch each time.
 
-This is different from the [MCP server](/docs/mcp): the MCP server runs inside a local Jupyter kernel, so using it means keeping a kernel process alive for the agent to connect to. Agent Skills carry no such requirement — they teach an agent to write and run retentioneering code directly, e.g. against your own files in its normal working environment, with no server to keep running.
+This is different from the [MCP server](/docs/mcp-server): the MCP server runs inside a local Jupyter kernel, so using it means keeping a kernel process alive for the agent to connect to. Agent Skills carry no such requirement — they teach an agent to write and run retentioneering code directly, e.g. against your own files in its normal working environment, with no server to keep running.
 
 ## Available skills
 

--- a/docs/guide/eventstream.md
+++ b/docs/guide/eventstream.md
@@ -188,4 +188,4 @@ prepared.recipe()
 #  {"type": "truncate_paths", "start_event": "path_start", "end_event": "purchase"}]
 ```
 
-`Eventstream.from_recipe(df, recipe)` replays that list onto a base DataFrame, rebuilding an identical eventstream — useful for moving a prepared pipeline between notebooks, storing it next to a report, or handing it to the [MCP server](/docs/mcp), whose preprocessor steps use exactly this format. `stream.fingerprint` (a property) is a content hash for checking two eventstreams really are the same, and `stream.equals(other)` compares them directly.
+`Eventstream.from_recipe(df, recipe)` replays that list onto a base DataFrame, rebuilding an identical eventstream — useful for moving a prepared pipeline between notebooks, storing it next to a report, or handing it to the [MCP server](/docs/mcp-server), whose preprocessor steps use exactly this format. `stream.fingerprint` (a property) is a content hash for checking two eventstreams really are the same, and `stream.equals(other)` compares them directly.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -41,7 +41,7 @@ More recipes like these live on the [Recipes](/docs/recipes) page.
 - **Fast on millions of rows.** The engine is backed by [DuckDB](https://duckdb.org), so exploration stays interactive on production-scale event logs — on your laptop.
 - **Your data, your rules.** Load events from pandas, CSV, or Parquet — whatever comes out of your warehouse. Custom event grouping, sessionization ([`split_sessions`](/docs/data-processors)), and cleanup are a chained method call away, with no SaaS interface limits.
 - **Notebook-native, shareable anywhere.** Widgets run in Jupyter, VS Code, and Google Colab, and every one of them exports to a standalone interactive HTML file you can drop into a message to a PM — no Python required to open it.
-- **AI-ready.** The built-in [MCP server](/docs/mcp) lets an LLM agent explore your eventstream with the full toolkit — ask "why did retention dip last week?" in plain language. [Agent Skills](/docs/agent-skills) teach coding agents like Claude Code or Codex how to run and contribute analyses in this codebase.
+- **AI-ready.** The built-in [MCP server](/docs/mcp-server) lets an LLM agent explore your eventstream with the full toolkit — ask "why did retention dip last week?" in plain language. [Agent Skills](/docs/agent-skills) teach coding agents like Claude Code or Codex how to run and contribute analyses in this codebase.
 
 ## Who is it for
 

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -4,6 +4,8 @@ retentioneering ships a built-in [Model Context Protocol](https://modelcontextpr
 
 The MCP server runs **locally** in the Jupyter kernel, so it requires a local Python environment. It will not work in cloud notebooks such as Google Colab.
 
+There is a second, unrelated MCP server that serves *this documentation* rather than your data, needs no installation, and is described at the bottom of this page: [Documentation MCP server](#documentation-mcp-server).
+
 ## Starting the server
 
 You can either start the server with no context so the agent will have to upload the eventstream itself to analyse it:
@@ -79,3 +81,35 @@ See also [Agent Skills](/docs/agent-skills) — instruction packages for coding 
 | `add_segment_overview(label, ...)` | Compute a segment overview and register it as a report tab. |
 | `check_analysis(analysis)` | Validate analysis text before export. |
 | `export_report(title, analysis, path)` | Generate a self-contained HTML report. |
+
+## Documentation MCP server
+
+Everything above describes the server that runs **on your machine, over your
+data**. There is a second one that runs **on our side, over this
+documentation**:
+
+```
+https://retentioneering.com/docs/mcp
+```
+
+It needs no installation, no kernel and no data — connect it to any MCP client
+and the agent can search and read these pages while it writes retentioneering
+code.
+
+Connecting is the same procedure as [above](#connecting-an-agent), with the
+URL instead of `localhost` — for example, in Claude Code:
+
+```bash
+claude mcp add --scope user --transport http retentioneering-docs https://retentioneering.com/docs/mcp
+```
+
+Three tools are available: `search_docs(query, limit)` returns the most relevant
+documentation sections with deep links, `get_doc_page(path)` returns one page in
+full, and `list_doc_pages()` returns the table of contents.
+
+If you would rather not connect a server at all, the same content is published
+as plain text following the [llms.txt convention](https://llmstxt.org):
+[`/llms.txt`](https://retentioneering.com/llms.txt) is the annotated table of
+contents, and [`/llms-full.txt`](https://retentioneering.com/llms-full.txt) is
+the entire documentation as one file (~200 KB, roughly 50k tokens — small
+enough to hand to an agent wholesale).

--- a/docs/guide/migration-from-3x.md
+++ b/docs/guide/migration-from-3x.md
@@ -6,7 +6,7 @@ If you are new to the library, you can skip this page entirely — start with th
 
 ## What changed, in one paragraph
 
-The pandas-based engine was replaced with a DuckDB-backed one, so the same analyses run at production-log scale on a laptop. The old iframe + CDN-loaded widgets were replaced with [anywidget](https://anywidget.dev)-based ones whose JavaScript is open source, lives in this repository, and ships inside the wheel — nothing is downloaded at runtime, and widgets now work in VS Code and Cursor as well as Jupyter. The `data_processor` / `preprocessor` / `params_model` machinery is gone: data processors are now plain methods with plain keyword arguments. And two things are new with no 3.x counterpart — an [MCP server](/docs/mcp) that lets an LLM agent drive the analysis, and the [Segment Overview](/docs/widgets/segment-overview) widget.
+The pandas-based engine was replaced with a DuckDB-backed one, so the same analyses run at production-log scale on a laptop. The old iframe + CDN-loaded widgets were replaced with [anywidget](https://anywidget.dev)-based ones whose JavaScript is open source, lives in this repository, and ships inside the wheel — nothing is downloaded at runtime, and widgets now work in VS Code and Cursor as well as Jupyter. The `data_processor` / `preprocessor` / `params_model` machinery is gone: data processors are now plain methods with plain keyword arguments. And two things are new with no 3.x counterpart — an [MCP server](/docs/mcp-server) that lets an LLM agent drive the analysis, and the [Segment Overview](/docs/widgets/segment-overview) widget.
 
 `CHANGELOG.md` in the repository holds the exhaustive, itemized delta under `[5.0.0]`.
 
@@ -72,7 +72,7 @@ No equivalent in 5.x today. These were cut deliberately to get the rewrite shipp
 
 | Gone | Closest thing available now |
 |---|---|
-| **Preprocessing Graph** (visual no-code pipeline builder) | Chained data processors in code; for agents, the [MCP server](/docs/mcp)'s preprocessor lists. |
+| **Preprocessing Graph** (visual no-code pipeline builder) | Chained data processors in code; for agents, the [MCP server](/docs/mcp-server)'s preprocessor lists. |
 | **Cohorts** | [`add_segment`](/docs/data-processors/add-segment) over a signup-period column plus [Segment Overview](/docs/widgets/segment-overview); [`to_daily_states`](/docs/data-processors/to-daily-states) for lifecycle-state retention. |
 | **StatTests** | Nothing built in — pull per-path values with [`get_metrics()`](/docs/eventstream#per-path-metrics-as-a-feature-table) and run your own test in `scipy`. |
 | **Sequences** | The `matches_pattern` [path metric](/docs/path-metrics) and `path_pattern` on [Step Matrix](/docs/widgets/step-matrix) / [Step Sankey](/docs/widgets/step-sankey) answer pattern questions, but there is no n-gram frequency table. |

--- a/docs/guide/path-analysis.md
+++ b/docs/guide/path-analysis.md
@@ -162,7 +162,7 @@ Also, treating sessions as paths might help: [Path as a sequence of sessions](/d
 
 ## Asking an agent instead
 
-The same techniques introduced on this page could be used by an LLM agent with the help of the built-in [MCP server](/docs/mcp) or [skills](/docs/agent-skills).
+The same techniques introduced on this page could be used by an LLM agent with the help of the built-in [MCP server](/docs/mcp-server) or [skills](/docs/agent-skills).
 
 ## Next steps
 
@@ -170,4 +170,4 @@ The same techniques introduced on this page could be used by an LLM agent with t
 - [Segments](/docs/segments) — how to define the groups you compare.
 - [Recipes](/docs/recipes) — these ideas applied to concrete product questions.
 - [Data processors](/docs/data-processors) — how to prepare the data for analysis.
-- [MCP server](/docs/mcp) — connecting an agent, the full tool list, and what it can and cannot do.
+- [MCP server](/docs/mcp-server) — connecting an agent, the full tool list, and what it can and cannot do.

--- a/docs/scripts/render_pages.py
+++ b/docs/scripts/render_pages.py
@@ -21,7 +21,9 @@ Usage (from repo root):
 
 from __future__ import annotations
 
+import re
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 
 import jinja2
@@ -34,7 +36,48 @@ GUIDE_DIR = REPO_ROOT / "docs" / "guide"
 IMG_DIR = REPO_ROOT / "docs" / "img"
 BUILD_DIR = REPO_ROOT / "docs" / "build"
 
+SITE_URL = "https://retentioneering.com"
+
 TITLE_OVERRIDES = {"urls_to_events": "URLs to Events"}
+
+# Guide pages in reading order, with the label the docs site shows in its
+# sidebar. Copying a guide page needs no such list (that's a plain glob), but
+# llms.txt does: it is an ordered table of contents, and alphabetical order
+# would put "Tracking" between "Segments" and "Widgets". Mirrors the NAV
+# constant in retentioneering-web's app/docs/layout.tsx; write_llms_files()
+# fails loudly if a file in docs/guide/ is missing here.
+GUIDES = [
+    ("index", "Introduction"),
+    ("quick-start", "Quick Start"),
+    ("installation", "Installation"),
+    ("path-analysis", "Path Analysis"),
+    ("eventstream", "Eventstream"),
+    ("widgets", "Widgets"),
+    ("data-processors", "Data Processors"),
+    ("segments", "Segments"),
+    ("path-metrics", "Path Metrics"),
+    ("mcp-server", "MCP Server"),
+    ("agent-skills", "Agent Skills"),
+    ("recipes", "Recipes"),
+    ("migration-from-3x", "Migrating from 3.x"),
+    ("tracking", "Tracking"),
+]
+
+# Descriptions in llms.txt are the page's own opening sentence. These pages
+# don't have a usable one — installation.md opens straight into a heading,
+# and the other two open on a hook rather than a definition.
+GUIDE_DESCRIPTIONS = {
+    "index": (
+        "What retentioneering is, what it is for, and how its pieces fit together."
+    ),
+    "installation": (
+        "Requirements, pip/uv install, optional dependencies, and Jupyter setup."
+    ),
+    "path-analysis": (
+        "The three aggregated representations of user paths — by step, by transition, "
+        "by milestone — and how to choose between them."
+    ),
+}
 
 WIDGETS = [
     ("widgets/transition-graph.md.jinja", "transition_graph", "transition_graph_data"),
@@ -130,8 +173,13 @@ def copy_guide_pages() -> None:
     Unlike widgets/data-processors, these have no docstring to render from —
     docs/guide/*.md IS the source, so this step is a plain copy, not a
     template render.
+
+    The output directory is wiped first: a page that was renamed or deleted
+    in docs/guide/ must disappear from the build too, or retentioneering-web
+    keeps serving the stale URL from its symlinked content/docs.
     """
     out_dir = BUILD_DIR / "guide"
+    shutil.rmtree(out_dir, ignore_errors=True)
     out_dir.mkdir(parents=True, exist_ok=True)
     for src in sorted(GUIDE_DIR.glob("*.md")):
         dest = out_dir / src.name
@@ -162,6 +210,168 @@ def copy_figures() -> None:
         print(f"wrote {dest.relative_to(REPO_ROOT)}")
 
 
+@dataclass
+class LlmsPage:
+    """One docs page as it appears in llms.txt / llms-full.txt."""
+
+    title: str
+    url: str
+    description: str
+    build_path: Path
+
+
+# <DemoWidget cmd={`stream.funnel(...)`} path="..." height={480} /> — a live
+# widget on the site, and nothing an LLM can use. The cmd is the interesting
+# part, so it becomes a plain python block; the attributes are dropped.
+DEMO_WIDGET_RE = re.compile(r"<DemoWidget\s+cmd=\{`(?P<cmd>.*?)`\}[^>]*/>", re.DOTALL)
+
+# Site-relative targets: markdown links (/docs/...) and figures (/docs-demos/...).
+# The trailing [^)\s]* stops before an image's optional " Caption" title.
+SITE_LINK_RE = re.compile(r"\]\((/docs[^)\s]*)")
+
+# First sentence: a period that ends a word, not one inside "3.3.0" or "5.0".
+FIRST_SENTENCE_RE = re.compile(r"^(.+?[.!?])(?:\s|$)")
+
+
+def _plain_text(text: str) -> str:
+    """Flatten inline markdown so a sentence can be used as a description."""
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = text.replace("**", "").replace("`", "")
+    return " ".join(text.split())
+
+
+def _lede(markdown: str) -> str:
+    """The first sentence of a page's first real paragraph.
+
+    Skips the H1, headings, blockquotes, lists, tables and JSX tags — a page
+    that opens on any of those has no lede and needs a GUIDE_DESCRIPTIONS entry.
+    """
+    paragraph: list[str] = []
+    for line in markdown.splitlines()[1:]:
+        stripped = line.strip()
+        if not stripped:
+            if paragraph:
+                break
+            continue
+        if stripped.startswith(("#", ">", "-", "*", "|", "```", "<", "!")):
+            break
+        paragraph.append(stripped)
+    sentence = _plain_text(" ".join(paragraph))
+    match = FIRST_SENTENCE_RE.match(sentence)
+    return match.group(1) if match else sentence
+
+
+def _collect_pages() -> dict[str, list[LlmsPage]]:
+    """Group every built page under its llms.txt section heading."""
+    on_disk = {path.stem for path in GUIDE_DIR.glob("*.md")}
+    listed = {stem for stem, _ in GUIDES}
+    if on_disk != listed:
+        raise SystemExit(
+            f"docs/guide/ and the GUIDES list disagree: "
+            f"missing from GUIDES {sorted(on_disk - listed)}, "
+            f"missing from docs/guide/ {sorted(listed - on_disk)}"
+        )
+
+    guides = []
+    for stem, label in GUIDES:
+        source = GUIDE_DIR / f"{stem}.md"
+        description = GUIDE_DESCRIPTIONS.get(stem) or _lede(
+            source.read_text(encoding="utf-8")
+        )
+        if not description:
+            raise SystemExit(
+                f"docs/guide/{stem}.md has no usable opening sentence — "
+                f"add a GUIDE_DESCRIPTIONS entry for it"
+            )
+        url = "/docs" if stem == "index" else f"/docs/{stem}"
+        guides.append(
+            LlmsPage(label, url, description, BUILD_DIR / "guide" / f"{stem}.md")
+        )
+
+    def from_method(method_name: str, section: str) -> LlmsPage:
+        slug = slugify(method_name)
+        return LlmsPage(
+            title=title_of(method_name),
+            url=f"/docs/{section}/{slug}",
+            # get_doc, not load_doc: a missing docstring is already reported
+            # once by the render pass, no need to warn about it twice.
+            description=_plain_text(
+                _lede(f"#\n\n{get_doc(Eventstream, method_name).summary}")
+            ),
+            build_path=BUILD_DIR / section / f"{slug}.md",
+        )
+
+    return {
+        "Guides": guides,
+        "Widgets": [from_method(name, "widgets") for _, name, _ in WIDGETS],
+        "Data processors": [
+            from_method(name, "data-processors") for name in DATA_PROCESSORS
+        ],
+    }
+
+
+def write_llms_files() -> None:
+    """Write llms.txt (a table of contents) and llms-full.txt (the whole corpus).
+
+    Both follow https://llmstxt.org: llms.txt is what an agent reads to find
+    the right page, llms-full.txt is the entire documentation as one file, for
+    agents that would rather hold all of it at once. The docs site serves them
+    from its root (/llms.txt, /llms-full.txt), so every link here is absolute.
+    """
+    sections = _collect_pages()
+
+    index = [
+        "# Retentioneering",
+        "",
+        "> Open-source Python library for user-behaviour analysis: it turns raw event "
+        "logs into interactive maps of how users move through a product — the paths "
+        "they take, the loops they get stuck in, the step where they leave. Everything "
+        "runs locally in a notebook, on a DuckDB-backed Eventstream.",
+        "",
+        f"The complete documentation as a single file: {SITE_URL}/llms-full.txt",
+        "",
+    ]
+    for heading, pages in sections.items():
+        index.append(f"## {heading}")
+        index.append("")
+        index += [f"- [{p.title}]({SITE_URL}{p.url}): {p.description}" for p in pages]
+        index.append("")
+    index += [
+        "## Optional",
+        "",
+        "- [Legacy documentation (v2.0, v3.3)](https://doc.retentioneering.com/3.3/doc/): "
+        "reference for the older, no-longer-developed releases. Only useful for reading "
+        "code written against one of those versions — the 5.x API differs throughout.",
+        "",
+    ]
+
+    blocks = []
+    for pages in sections.values():
+        for page in pages:
+            body = page.build_path.read_text(encoding="utf-8").strip()
+            body = DEMO_WIDGET_RE.sub(
+                lambda m: f"```python\n{m.group('cmd').strip()}\n```", body
+            )
+            body = SITE_LINK_RE.sub(lambda m: f"]({SITE_URL}{m.group(1)}", body)
+            lines = body.splitlines()
+            heading, rest = (
+                (lines[0], "\n".join(lines[1:]).lstrip("\n"))
+                if lines and lines[0].startswith("# ")
+                else (f"# {page.title}", body)
+            )
+            blocks.append(f"{heading}\n\nSource: {SITE_URL}{page.url}\n\n{rest}")
+
+    for name, text in (
+        ("llms.txt", "\n".join(index)),
+        ("llms-full.txt", "\n\n---\n\n".join(blocks) + "\n"),
+    ):
+        out_path = BUILD_DIR / name
+        out_path.write_text(text, encoding="utf-8")
+        print(
+            f"wrote {out_path.relative_to(REPO_ROOT)} ({out_path.stat().st_size / 1024:.0f} KB)"
+        )
+
+
 def main() -> None:
     (BUILD_DIR / "widgets").mkdir(parents=True, exist_ok=True)
     (BUILD_DIR / "data-processors").mkdir(parents=True, exist_ok=True)
@@ -181,6 +391,9 @@ def main() -> None:
         out_path = BUILD_DIR / "data-processors" / f"{slugify(method_name)}.md"
         out_path.write_text(rendered, encoding="utf-8")
         print(f"wrote {out_path.relative_to(REPO_ROOT)}")
+
+    # Last: llms-full.txt concatenates the pages written above.
+    write_llms_files()
 
 
 if __name__ == "__main__":

--- a/notebooks/api_showcase.ipynb
+++ b/notebooks/api_showcase.ipynb
@@ -10529,7 +10529,7 @@
     "- [Documentation](https://retentioneering.com/docs/) — guides and the full API reference.\n",
     "- `ecom_demo.ipynb` — a narrative walkthrough of the same dataset: stories,\n",
     "  anomalies, and how to investigate them with these tools.\n",
-    "- [MCP server](https://retentioneering.com/docs/mcp) — `retentioneering.mcp.serve(stream)` exposes the\n",
+    "- [MCP server](https://retentioneering.com/docs/mcp-server) — `retentioneering.mcp.serve(stream)` exposes the\n",
     "  eventstream to Claude or any MCP client for agent-driven analysis."
    ]
   }


### PR DESCRIPTION
render_pages.py now emits two more artifacts alongside the pages:

- llms.txt, an annotated table of contents per the llms.txt convention. Descriptions are each page's own opening sentence; GUIDE_DESCRIPTIONS overrides only the pages that open on a heading or a hook.
- llms-full.txt, the whole corpus (~200 KB) in one file, with site-relative links absolutised and <DemoWidget> tags replaced by the python they run.

Page order comes from the new GUIDES list, which mirrors the docs nav in retentioneering-web; a guide page missing from it now fails the build rather than silently dropping out of the index. copy_guide_pages() also wipes its output directory first, so a renamed or deleted page cannot linger in the build and keep its URL alive on the site.

The guide about the library's own MCP server moves from /docs/mcp to /docs/mcp-server, freeing that path for the hosted documentation MCP server (implemented in retentioneering-web, which serves both llms files and reads llms-full.txt as its corpus). The old URL is deliberately not redirected. The guide gains a section explaining the split between the two servers.

Rationale for all of the above is recorded in ADR-0014.