### PR TITLE
Fix funnel widget clipping content instead of scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Funnel widget: with more steps than the default `height=420` could fit, the chart and the bottom rows of the table were clipped with no way to reach them. The scroll container declared `flex: 1` inside a non-flex wrapper, so it never got a definite height and `overflow-y: auto` stayed inert; it is now a direct flex child with `min-height: 0` and the funnel content scrolls vertically inside the widget frame
 - Cluster Analysis widget: selecting **Standard** feature scaling in the sidebar raised `ValueError: Unknown scaler: std` — the sidebar sends `"std"` while the Python side only accepted `"standard"`. `"std"` is now the canonical spelling on both sides; `"standard"` is still accepted as a legacy alias, so code written against 5.1.0 and earlier keeps working
 
 ## [5.1.0] - 2026-07-23

--- a/js/widget/src/funnel.tsx
+++ b/js/widget/src/funnel.tsx
@@ -686,22 +686,23 @@ export function render({ host, el, isStatic = false }: RenderContext) {
       <div style={{ display: "flex", flexDirection: "row", height: computedHeight, background: "#ffffff", borderRadius: 8, overflow: "hidden", border: "1px solid #e2e8f0", fontFamily: "system-ui,-apple-system,sans-serif" }}>
         <div style={{ flex: 1, position: "relative", overflow: "hidden", minWidth: 0, display: "flex", flexDirection: "column" }}>
           <SidebarToggle onClick={handleToggle} />
-          <div style={{ width: "100%", height: "100%" }}>
-            <div style={{ flex: 1, overflowY: "auto", padding: 16 }}>
-              {funnelSteps.length === 0 && !isLoading && (
-                <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%", color: "#9ca3af", fontSize: 13 }}>
-                  Add steps in the settings panel to build the funnel
+          {/* flex:1 + minHeight:0 makes this the scroll container: without a
+              definite height overflowY:auto never engages and the chart+table
+              simply get clipped by the parent's overflow:hidden. */}
+          <div style={{ flex: 1, minHeight: 0, overflowY: "auto", padding: 16 }}>
+            {funnelSteps.length === 0 && !isLoading && (
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%", color: "#9ca3af", fontSize: 13 }}>
+                Add steps in the settings panel to build the funnel
+              </div>
+            )}
+            {funnelSteps.length > 0 && (
+              <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+                <FunnelChart steps={funnelSteps} hasDiff={hasDiff} label1={label1} label2={label2} chartH={CHART_H} />
+                <div style={{ width: "100%" }}>
+                  <FunnelTable steps={funnelSteps} hasDiff={hasDiff} label1={label1} label2={label2} result={result} />
                 </div>
-              )}
-              {funnelSteps.length > 0 && (
-                <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
-                  <FunnelChart steps={funnelSteps} hasDiff={hasDiff} label1={label1} label2={label2} chartH={CHART_H} />
-                  <div style={{ width: "100%" }}>
-                    <FunnelTable steps={funnelSteps} hasDiff={hasDiff} label1={label1} label2={label2} result={result} />
-                  </div>
-                </div>
-              )}
-            </div>
+              </div>
+            )}
           </div>
           {isLoading && <ComputingSpinner />}
         </div>


### PR DESCRIPTION
## Problem

`FunnelWidget` defaults to `height=420`. With enough steps the chart plus table exceed that, and the extra content was **clipped** — the lower table rows were simply unreachable.

The auto-height path never helped: `computedHeight = heightProp > 0 ? heightProp : autoHeight(...)` and Python always sends a non-zero `height`, so `autoHeight()` is only reachable if you explicitly pass `height=0`.

The actual bug is in the scroll chain in `js/widget/src/funnel.tsx`:

- the widget frame has `height: computedHeight; overflow: hidden`
- inside it sat a redundant `<div style={{width:"100%", height:"100%"}}>` — a plain block, **not** a flex container
- the scroll container declared `flex: 1; overflow-y: auto`, but `flex: 1` on a child of a non-flex parent is ignored, so its height stayed `auto` and `overflow-y: auto` never engaged (a scrollbar needs a definite height)

Result: content grew freely and got cut off by the frame's `overflow: hidden`. `CHART_H` is clamped at `CHART_MIN_H = 200`px and the table adds `34 + n * 30`px, so ~10 steps overflow a 420px frame by roughly 200px.

## Fix

Remove the wrapper and make the scroll container a direct flex child of the column: `flex: 1; min-height: 0; overflow-y: auto`. `min-height: 0` is the essential half — without it a flex item won't shrink below its content size and the scrollbar still wouldn't appear.

Horizontal scrolling (`overflow-x: auto` in `FunnelChart`) was already correct and is untouched.

## Testing

`make build` passes. Verified by the reporter in Jupyter on a multi-step funnel: the frame stays at 420px and the content now scrolls inside it.

Not covered by automated tests — widget rendering is out of scope for `tests/` (per AGENTS.md), and JS has no test suite.

## Note

This keeps the widget a fixed-height scrolling frame. Making it grow to fit the steps instead (default `height=None`, letting the already-written `autoHeight()` do its job) is a separate product decision, deliberately not made here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)