### PR TITLE
Fix Step Sankey hiding path_start/path_end among regular events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - Funnel widget: with more steps than the default `height=420` could fit, the chart and the bottom rows of the table were clipped with no way to reach them. The scroll container declared `flex: 1` inside a non-flex wrapper, so it never got a definite height and `overflow-y: auto` stayed inert; it is now a direct flex child with `min-height: 0` and the funnel content scrolls vertically inside the widget frame
+- Step Sankey: `path_start`/`path_end` were hard-excluded from every non-anchor column, hiding real (non-zero) values — e.g. `path_end`'s cumulative drop-off in the steps after the anchor never showed up, even though the same numbers are visible as ordinary rows in the Step Matrix table. They now compete for the top-N slots like any other event in variable columns; the two fixed anchor columns are unaffected
 - Cluster Analysis widget: selecting **Standard** feature scaling in the sidebar raised `ValueError: Unknown scaler: std` — the sidebar sends `"std"` while the Python side only accepted `"standard"`. `"std"` is now the canonical spelling on both sides; `"standard"` is still accepted as a legacy alias, so code written against 5.1.0 and earlier keeps working
 
 ## [5.1.0] - 2026-07-23

--- a/js/viz-core/src/stores/StepMatrixStore.ts
+++ b/js/viz-core/src/stores/StepMatrixStore.ts
@@ -648,7 +648,6 @@ export class StepMatrixStore {
     matrixIndex: number = this.activeMatrixIndex,
   ): { top: Event[]; rest: Event[] } => {
     const eventsWithValues = this.visibleEvents
-      .filter((e) => !this.isImmutable(e.id)) // path_start/path_end only as fixed anchors
       .map((event) => {
         const value = this.getMatrixValue(event.id, stepIndex, matrixIndex);
         return { event, value };


### PR DESCRIPTION
## Summary
- `StepMatrixStore.getTopEvents()` hard-excluded `path_start`/`path_end` from every non-anchor step column, so they only ever rendered as the two fixed boundary columns — even where they carried real, non-zero values (e.g. `path_end`'s cumulative drop-off count in the steps following the anchor)
- The Step Matrix table (the numeric twin of the Sankey diagram) already renders these as ordinary rows across every step, so the same underlying data was visible there but silently dropped in the Sankey view
- Removed the exclusion filter; the existing fixed-anchor logic in `StepColumn`/`ConnectionLayer` still isolates the two boundary columns, and `ConnectionLayer`'s `canBeSource`/`canBeTarget` rules still correctly forbid ribbons flowing out of `path_end` or into `path_start`, so no ribbons are drawn where they shouldn't be

## Test plan
- [x] `make build` — JS builds clean
- [x] Verified via a synthetic eventstream (paths of varying lengths) rendered through `export_html` + headless Chromium: `path_end` now appears as a growing node at each step where paths terminate, with no outgoing ribbon from it
- [x] Confirmed the 3 pre-existing `tsc --noEmit` errors (`SettingsSidebar.tsx`, `StepColumn.tsx`) are unrelated to this change and predate it
- [x] `pre-commit` hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)