### PR TITLE
Add render_static() for embedding widgets in a notebook's own HTML export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Every widget now has `render_static()`, an `export_html()` sibling that returns an `IPython.display.HTML` object instead of writing a file — use it in place of a live widget in any cell you want to survive `jupyter nbconvert` / "Save and Export as HTML", which replay stored outputs without a kernel. Without `state_file`, it only reflects the widget object's own state, not a live in-browser arrangement (e.g. dragged graph nodes) made on a different object
 - Docs: `render_pages.py` now also writes `llms.txt` (annotated table of contents, per the [llms.txt convention](https://llmstxt.org)) and `llms-full.txt` (the whole documentation as one ~200 KB file), served at `retentioneering.com/llms.txt` and `/llms-full.txt`. Descriptions are each page's own opening sentence; a guide page missing from the new `GUIDES` order list fails the build (ADR-0014)
 - Docs: a documentation MCP server at `https://retentioneering.com/docs/mcp` — hosted, stateless, no installation, with `search_docs` / `get_doc_page` / `list_doc_pages`. Distinct from the library's own `rete.mcp.serve()`, which is local and works on your data; the [MCP Server](https://retentioneering.com/docs/mcp-server) guide explains the split. Implementation lives in retentioneering-web (ADR-0014)
 

--- a/docs/guide/widgets.md
+++ b/docs/guide/widgets.md
@@ -156,3 +156,54 @@ and display parameters plus extras like node layout, filters, sorting, scroll
 position, and zoom (results are recomputed, not saved) — so re-running the
 cell restores the widget exactly as you left it. Explicitly passed arguments
 override the loaded state.
+
+## Rendering for a notebook's own HTML export
+
+A widget displayed normally in Jupyter is a live `anywidget` — it needs a
+running Python kernel behind it. `jupyter nbconvert` and "Save and Export as
+HTML" don't run a kernel; they just replay each cell's already-stored output.
+A live widget's output has nothing useful stored for that replay, so it shows
+up blank (or stuck) in the exported file.
+
+`render_static()` solves this the same way [`export_html()`](/docs/widgets#exporting-to-html) does — it bakes
+the widget's current state into a self-contained page with no kernel
+dependency — but instead of writing a file, it returns an
+`IPython.display.HTML` object you use in place of the widget as a cell's
+output, so it survives the notebook's own export:
+
+```python
+stream.transition_graph(edge_weight="proba_out").render_static()
+```
+
+### Reproducing interactive state
+
+`render_static()` only ever sees this specific widget object's own state.
+**Without `state_file`, it may not match what you see on screen.**
+It has no way to know about manual, in-browser arrangements (e.g. transition
+graph nodes you dragged) made on a different widget object, even one built
+from identical data and parameters — dragging updates that object's own
+traitlets and the browser's local cache, neither of which a later,
+independently-constructed widget can see. So this does **not** work:
+
+```python
+stream.transition_graph()                     # drag some nodes here...
+stream.transition_graph().render_static()     # ...doesn't see them: fresh object, no state_file
+```
+
+To make an interactively-arranged layout reproducible for `render_static()`
+or `export_html()`, construct the widget with `state_file=` from the start:
+
+```python
+stream.transition_graph(state_file="my_graph.json")                  # drag some nodes here...
+stream.transition_graph(state_file="my_graph.json").render_static()  # ... sees the drag
+```
+
+### Rendering parameters
+
+`render_static()` takes:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `title` | `str \| None` | Title shown in the browser tab if the embedded page is opened on its own. Defaults to the widget's name, e.g. `"Transition Graph"`. |
+| `height` | `int \| str \| None` | Height in pixels, or any CSS length (e.g. `"80vh"`). Defaults to the widget's current `height`. |
+| `sidebar_open` | `bool \| None` | Whether the settings sidebar starts open. Defaults to the widget's current `sidebar_open` value. |

--- a/src/retentioneering/widgets/_base.py
+++ b/src/retentioneering/widgets/_base.py
@@ -44,6 +44,7 @@ import traitlets
 
 from retentioneering.exceptions import WidgetExportError
 from retentioneering.widgets._esm import _get_esm
+from retentioneering.widgets._html_export import render_static_display, write_html
 from retentioneering.widgets._state_file import StateFileMixin
 
 _STATIC = pathlib.Path(__file__).parent.parent / "static"
@@ -98,6 +99,11 @@ class RetentioneeringWidget(StateFileMixin, anywidget.AnyWidget):
     #: than an AttributeError).
     compute_tools: dict[str, Callable[["RetentioneeringWidget", dict], Any]] = {}
 
+    #: Display name used as the browser-tab/tab-label default for
+    #: ``export_html()``/``render_static()`` (e.g. ``"Transition Graph"``).
+    #: Every subclass overrides this.
+    _export_label: str = ""
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.observe(self._on_compute_request, names=["compute_request"])
@@ -116,6 +122,98 @@ class RetentioneeringWidget(StateFileMixin, anywidget.AnyWidget):
             raise WidgetExportError(
                 f"Cannot export: the widget's last computation failed: {self.error}"
             )
+
+    def _export_data(self, sidebar_open: bool | None = None) -> dict[str, Any]:
+        """Data payload for ``export_html()``/``render_static()``.
+
+        Every subclass overrides this with its own traitlet -> dict mapping;
+        this base implementation only exists so a subclass that forgets to
+        override it fails with a clear ``NotImplementedError`` here rather
+        than an ``AttributeError`` inside ``export_html``.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement _export_data()"
+        )
+
+    def export_html(
+        self,
+        path: str,
+        title: str | None = None,
+        analysis: str | None = None,
+        sidebar_open: bool | None = None,
+    ) -> None:
+        """
+        Export this widget as a standalone interactive HTML file.
+
+        Parameters
+        ----------
+        path:
+            Destination file path.
+        title:
+            Title shown in the browser tab. Defaults to the widget's name,
+            e.g. ``"Transition Graph"``.
+        analysis:
+            Optional analysis text. Wrap event names in square brackets to
+            make them clickable, e.g.
+            ``"Drop-off at [basket]: 78% of users leave here."``. Supports
+            basic markdown (bold, italic, bullet lists, tables, headings).
+        sidebar_open:
+            Whether the settings sidebar starts open in the exported file.
+            Defaults to the widget's current ``sidebar_open`` value.
+        """
+        self._raise_if_error()
+        data = self._export_data(sidebar_open)
+        write_html(
+            path, title or self._export_label, self._export_label, data, analysis
+        )
+
+    def render_static(
+        self,
+        title: str | None = None,
+        height: int | str | None = None,
+        sidebar_open: bool | None = None,
+    ):
+        """
+        Render this widget for embedding in a notebook's own HTML export.
+
+        Unlike just leaving the widget as a cell's output, this doesn't need
+        a live kernel to render: it bakes the same self-contained page
+        ``export_html()`` writes to disk into the cell's output (as an
+        ``<iframe srcdoc>``), so it keeps showing correctly after
+        ``jupyter nbconvert`` / "Save and Export as HTML" — those replay
+        stored cell outputs without a kernel, and a live widget needs one.
+        Use it in place of the widget in any cell you plan to keep visible
+        after exporting the notebook.
+
+        It reads whatever is currently in this widget's own traitlets — it
+        has no way to see manual, in-browser interactions (e.g. dragged node
+        positions) made on a *different* call/instance, even one that looks
+        identical (same data, same params). If you want the export to
+        reflect a layout you arranged by hand, construct the widget with
+        ``state_file=`` first: manual changes then auto-save to that file as
+        you make them, and any later widget instance built with the same
+        ``state_file`` — including one you're about to call ``render_static()``
+        on — loads it back synchronously, before anything else runs. Without
+        ``state_file``, a fresh call always starts from the widget's default
+        (or algorithmic, e.g. semantic graph layout) state, regardless of
+        what you previously did to another instance in the notebook.
+
+        Parameters
+        ----------
+        title:
+            Title shown in the browser tab if the iframe is opened on its
+            own. Defaults to the widget's name, e.g. ``"Transition Graph"``.
+        height:
+            iframe height in pixels, or any CSS length (e.g. ``"80vh"``).
+            Defaults to the widget's current ``height``.
+        sidebar_open:
+            Whether the settings sidebar starts open.
+            Defaults to the widget's current ``sidebar_open`` value.
+        """
+        self._raise_if_error()
+        data = self._export_data(sidebar_open)
+        resolved_height = height if height is not None else data["height"]
+        return render_static_display(title or self._export_label, data, resolved_height)
 
     # ── compute RPC plumbing ────────────────────────────────────────────────
 

--- a/src/retentioneering/widgets/_html_export.py
+++ b/src/retentioneering/widgets/_html_export.py
@@ -10,6 +10,14 @@ import html as _html_mod
 _BUNDLE_PATH = pathlib.Path(__file__).parent.parent / "static" / "widget-static.js"
 _CSS_PATH = pathlib.Path(__file__).parent.parent / "static" / "widget.css"
 
+#: `#retentioneering-root`'s margin in `_HTML_TEMPLATE_BARE` (all four sides).
+#: `render_static_html()` adds `2 * _ROOT_MARGIN_PX` to a pixel `height` up
+#: front, so the iframe's *starting* size already matches what the page's own
+#: `ResizeObserver` would report — without this, every render_static() call
+#: opens 2 * _ROOT_MARGIN_PX short and shows a (briefly, or if the resize
+#: message never arrives, permanently) scrolling iframe.
+_ROOT_MARGIN_PX = 24
+
 
 def _json_for_script(obj: object) -> str:
     """Serialize ``obj`` to JSON safe for embedding inside a ``<script>`` block.
@@ -283,8 +291,13 @@ def render_analysis(text: str, label_map: dict | None = None) -> str:
 # ── Templates ──────────────────────────────────────────────────────────────────
 
 
-def _write_bare(path: str, title: str, data: dict) -> None:
-    """Single widget, no analysis panel."""
+def render_bare_html(title: str, data: dict) -> str:
+    """Single-widget standalone page (no analysis panel), as a string.
+
+    Shared by ``_write_bare`` (writes it to a file, for ``export_html``) and
+    ``render_static_html`` (embeds it in an ``<iframe srcdoc>``, for
+    ``render_static``) — same self-contained page either way.
+    """
     if not _BUNDLE_PATH.exists():
         raise FileNotFoundError(
             f"Static bundle not found at {_BUNDLE_PATH}. "
@@ -292,13 +305,90 @@ def _write_bare(path: str, title: str, data: dict) -> None:
         )
     bundle_js = _BUNDLE_PATH.read_text(encoding="utf-8")
     widget_css = _CSS_PATH.read_text(encoding="utf-8")
-    html = (
+    return (
         _HTML_TEMPLATE_BARE.replace("{{TITLE}}", _html_mod.escape(title))
         .replace("{{DATA_JSON}}", _json_for_script(data))
         .replace("{{BUNDLE_JS}}", bundle_js)
         .replace("{{WIDGET_CSS}}", widget_css)
+        .replace("{{ROOT_MARGIN}}", str(_ROOT_MARGIN_PX))
     )
-    pathlib.Path(path).write_text(html, encoding="utf-8")
+
+
+def _write_bare(path: str, title: str, data: dict) -> None:
+    """Single widget, no analysis panel."""
+    pathlib.Path(path).write_text(render_bare_html(title, data), encoding="utf-8")
+
+
+def render_static_html(title: str, data: dict, height: int | str) -> str:
+    """Wrap a single-widget export page in a self-contained ``<iframe srcdoc>``.
+
+    For embedding a widget's *current* state directly into a notebook cell's
+    output (via ``render_static()``) so it survives ``jupyter nbconvert`` /
+    "Save and Export as HTML" — those only capture a notebook's stored cell
+    outputs, they don't run a kernel, so a live anywidget can't render there.
+    The iframe carries the exact same self-contained page ``export_html()``
+    writes to disk (own ``<head>``, inlined JS bundle, no kernel needed), just
+    inlined as a string instead of a file. ``srcdoc`` (not ``src``) means the
+    whole page travels with the notebook's HTML export as a single file, and
+    isolates each widget's globals/DOM ids from any other widget in the same
+    notebook.
+
+    ``height`` is only the *starting* height (shown until the page inside the
+    iframe reports its real size — see ``_HTML_TEMPLATE_BARE``'s
+    ``ResizeObserver``/``postMessage``); the inline script below listens for
+    that message and grows/shrinks the iframe to fit, so the export doesn't
+    end up with an inner scrollbar or clipped content. ``document
+    .currentScript.previousElementSibling`` (rather than an id) targets this
+    exact iframe so multiple widgets in one notebook don't collide.
+
+    A pixel ``height`` (as opposed to a caller-supplied CSS length like
+    ``"80vh"``) is a widget's own ``height`` trait, i.e. exactly what
+    ``#retentioneering-root``'s content measures *before* its
+    ``2 * _ROOT_MARGIN_PX`` margin — added here so the very first paint
+    already matches what the resize message would report, instead of
+    starting ``2 * _ROOT_MARGIN_PX`` short and visibly scrolling until the
+    first ``ResizeObserver`` callback lands (or forever, if it never does —
+    e.g. a notebook frontend that sandboxes/strips inline ``<script>``).
+    """
+    page = render_bare_html(title, data)
+    height_css = (
+        f"{height + 2 * _ROOT_MARGIN_PX}px" if isinstance(height, int) else height
+    )
+    escaped = _html_mod.escape(page, quote=True)
+    return (
+        f'<iframe srcdoc="{escaped}" '
+        f'style="width:100%;height:{height_css};border:0;display:block;'
+        f'transition:height .15s ease"></iframe>'
+        "<script>(function () {"
+        "var f = document.currentScript.previousElementSibling;"
+        "window.addEventListener('message', function (e) {"
+        "if (e.source === f.contentWindow && e.data "
+        "&& e.data.source === 'retentioneering-widget') {"
+        "f.style.height = e.data.height + 'px';"
+        "}"
+        "});"
+        "})();</script>"
+    )
+
+
+def render_static_display(title: str, data: dict, height: int | str):
+    """``render_static_html()``, wrapped as an ``IPython.display.HTML`` object.
+
+    ``IPython.display.HTML`` warns "Consider using IPython.display.IFrame
+    instead" for any string that looks like an ``<iframe>...</iframe>`` — a
+    heuristic aimed at plain ``src=`` iframes. ``IFrame`` has no ``srcdoc``
+    support, so that suggestion doesn't apply to us; suppressed narrowly here
+    rather than at the call sites.
+    """
+    import warnings
+
+    from IPython.display import HTML
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message="Consider using IPython.display.IFrame instead"
+        )
+        return HTML(render_static_html(title, data, height))
 
 
 _HTML_TEMPLATE_BARE = """<!DOCTYPE html>
@@ -311,7 +401,7 @@ _HTML_TEMPLATE_BARE = """<!DOCTYPE html>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body { background: #f8fafc; display: flex; align-items: center;
            justify-content: center; min-height: 100vh; }
-    #retentioneering-root { width: 100%; max-width: 1400px; margin: 24px; }
+    #retentioneering-root { width: 100%; max-width: 1400px; margin: {{ROOT_MARGIN}}px; }
   </style>
   <style>{{WIDGET_CSS}}</style>
 </head>
@@ -329,6 +419,38 @@ _HTML_TEMPLATE_BARE = """<!DOCTYPE html>
       if (vm) window.__HS_DATA__.view = vm[1];
     })();
     RetentioneeringWidget.renderStatic(window.__HS_DATA__, document.getElementById('retentioneering-root'));
+    // Embedded in a render_static() iframe: report our real content
+    // height to the parent page so it can size the iframe to fit (see
+    // render_static_html()'s listener) instead of leaving a fixed height
+    // that scrolls or clips. No-op when opened directly (window.parent ===
+    // window) or in browsers without ResizeObserver.
+    if (window.parent !== window && window.ResizeObserver) {
+      var __root = document.getElementById('retentioneering-root');
+      var __lastSent = -1;
+      var __pending = null;
+      var __send = function () {
+        var cs = getComputedStyle(__root);
+        var h = Math.ceil(
+          __root.getBoundingClientRect().height +
+          parseFloat(cs.marginTop) + parseFloat(cs.marginBottom)
+        );
+        if (h && h !== __lastSent) {
+          __lastSent = h;
+          window.parent.postMessage({ source: 'retentioneering-widget', height: h }, '*');
+        }
+      };
+      // Debounced: React mounts in stages (empty root -> content), so the
+      // observer's first callbacks fire against a still-growing tree. Firing
+      // postMessage on every one of those flashes the iframe down to ~0 and
+      // back up as the parent applies each intermediate size in turn.
+      // Waiting for 120ms of quiet before reporting only ever sends the
+      // settled height.
+      var __debounced = function () {
+        if (__pending) clearTimeout(__pending);
+        __pending = setTimeout(__send, 120);
+      };
+      new ResizeObserver(__debounced).observe(__root);
+    }
   </script>
 </body>
 </html>"""

--- a/src/retentioneering/widgets/cluster_analysis.py
+++ b/src/retentioneering/widgets/cluster_analysis.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
 from retentioneering.exceptions import RetentioneeringError
 from retentioneering.tools.cluster_analysis import parse_n_clusters as _parse_n_clusters
 from retentioneering.widgets._base import _UNSET, RetentioneeringWidget
-from retentioneering.widgets._html_export import write_html
 
 
 class ClusterAnalysisWidget(RetentioneeringWidget):
@@ -452,32 +451,12 @@ class ClusterAnalysisWidget(RetentioneeringWidget):
         except Exception:
             pass
 
-    # ── HTML export ───────────────────────────────────────────────────────────
+    # ── HTML export (export_html/render_static: see RetentioneeringWidget) ────
 
-    def export_html(
-        self,
-        path: str,
-        title: str = "Cluster Analysis",
-        analysis: str | None = None,
-        sidebar_open: bool | None = None,
-    ) -> None:
-        """
-        Export the cluster analysis as a standalone interactive HTML file.
+    _export_label = "Cluster Analysis"
 
-        Parameters
-        ----------
-        path:
-            Destination file path.
-        title:
-            Title shown in the browser tab.
-        analysis:
-            Optional analysis text. Supports basic markdown and [event] links.
-        sidebar_open:
-            Whether the settings sidebar starts open in the exported file.
-            Defaults to the widget's current ``sidebar_open`` value.
-        """
-        self._raise_if_error()
-        data = {
+    def _export_data(self, sidebar_open: bool | None = None) -> dict:
+        return {
             "widget_type": "cluster_analysis",
             "result": json.loads(self.result or "{}"),
             "features": json.loads(self.features or "[]"),
@@ -500,7 +479,6 @@ class ClusterAnalysisWidget(RetentioneeringWidget):
             "active_tab": self.active_tab or "",
             "cluster_renames": json.loads(self.cluster_renames or "{}"),
         }
-        write_html(path, title, "Cluster Analysis", data, analysis)
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────

--- a/src/retentioneering/widgets/funnel.py
+++ b/src/retentioneering/widgets/funnel.py
@@ -5,7 +5,6 @@ import traitlets
 from retentioneering.exceptions import RetentioneeringError
 from retentioneering.widgets._base import _UNSET, RetentioneeringWidget
 from retentioneering.widgets._utils import parse_diff as _parse_diff
-from retentioneering.widgets._html_export import write_html
 
 
 class FunnelWidget(RetentioneeringWidget):
@@ -161,32 +160,12 @@ class FunnelWidget(RetentioneeringWidget):
                 result["total_paths"] = round(up / r) if r > 0 else up
         return result
 
-    # ── HTML export ───────────────────────────────────────────────────────────
+    # ── HTML export (export_html/render_static: see RetentioneeringWidget) ────
 
-    def export_html(
-        self,
-        path: str,
-        title: str = "Funnel",
-        analysis: str | None = None,
-        sidebar_open: bool | None = None,
-    ) -> None:
-        """
-        Export the funnel as a standalone interactive HTML file.
+    _export_label = "Funnel"
 
-        Parameters
-        ----------
-        path:
-            Destination file path.
-        title:
-            Title shown in the browser tab.
-        analysis:
-            Optional analysis text. Supports basic markdown and [event] links.
-        sidebar_open:
-            Whether the settings sidebar starts open in the exported file.
-            Defaults to the widget's current ``sidebar_open`` value.
-        """
-        self._raise_if_error()
-        data = {
+    def _export_data(self, sidebar_open: bool | None = None) -> dict:
+        return {
             "widget_type": "funnel",
             "result": json.loads(self.result or "{}"),
             "steps": json.loads(self.steps or "[]"),
@@ -200,4 +179,3 @@ class FunnelWidget(RetentioneeringWidget):
             if sidebar_open is not None
             else self.sidebar_open,
         }
-        write_html(path, title, "Funnel", data, analysis)

--- a/src/retentioneering/widgets/segment_overview.py
+++ b/src/retentioneering/widgets/segment_overview.py
@@ -4,7 +4,6 @@ import traitlets
 
 from retentioneering.exceptions import RetentioneeringError
 from retentioneering.widgets._base import _UNSET, RetentioneeringWidget
-from retentioneering.widgets._html_export import write_html
 
 
 class SegmentOverviewWidget(RetentioneeringWidget):
@@ -179,17 +178,12 @@ class SegmentOverviewWidget(RetentioneeringWidget):
             "values": [[_safe(v) for v in df.loc[m].tolist()] for m in df.index],
         }
 
-    # ── HTML export ───────────────────────────────────────────────────────────
+    # ── HTML export (export_html/render_static: see RetentioneeringWidget) ────
 
-    def export_html(
-        self,
-        path: str,
-        title: str = "Segment Overview",
-        analysis: str | None = None,
-        sidebar_open: bool | None = None,
-    ) -> None:
-        self._raise_if_error()
-        data = {
+    _export_label = "Segment Overview"
+
+    def _export_data(self, sidebar_open: bool | None = None) -> dict:
+        return {
             "widget_type": "segment_overview",
             "result": json.loads(self.result or "{}"),
             "segment_col": self.segment_col or "",
@@ -204,7 +198,6 @@ class SegmentOverviewWidget(RetentioneeringWidget):
             if sidebar_open is not None
             else self.sidebar_open,
         }
-        write_html(path, title, "Segment Overview", data, analysis)
 
     def _compute_distribution(self, req: dict):
         self.is_loading = True

--- a/src/retentioneering/widgets/step_matrix.py
+++ b/src/retentioneering/widgets/step_matrix.py
@@ -6,7 +6,6 @@ from retentioneering.exceptions import RetentioneeringError
 from retentioneering.widgets._base import _UNSET, RetentioneeringWidget
 from retentioneering.widgets._utils import parse_diff as _parse_diff
 from retentioneering.widgets._utils import step_matrix_blocks as _step_matrix_blocks
-from retentioneering.widgets._html_export import write_html
 
 
 class StepMatrixWidget(RetentioneeringWidget):
@@ -264,32 +263,12 @@ class StepMatrixWidget(RetentioneeringWidget):
             "event_counts_g2": event_counts_g2,
         }
 
-    # ── HTML export ───────────────────────────────────────────────────────────
+    # ── HTML export (export_html/render_static: see RetentioneeringWidget) ────
 
-    def export_html(
-        self,
-        path: str,
-        title: str = "Step Matrix",
-        analysis: str | None = None,
-        sidebar_open: bool | None = None,
-    ) -> None:
-        """
-        Export the step matrix as a standalone interactive HTML file.
+    _export_label = "Step Matrix"
 
-        Parameters
-        ----------
-        path:
-            Destination file path.
-        title:
-            Title shown in the browser tab.
-        analysis:
-            Optional analysis text. Supports basic markdown and [event] links.
-        sidebar_open:
-            Whether the settings sidebar starts open in the exported file.
-            Defaults to the widget's current ``sidebar_open`` value.
-        """
-        self._raise_if_error()
-        data = {
+    def _export_data(self, sidebar_open: bool | None = None) -> dict:
+        return {
             "widget_type": "step_matrix",
             "result": json.loads(self.result or "{}"),
             "max_steps": self.max_steps,
@@ -314,7 +293,6 @@ class StepMatrixWidget(RetentioneeringWidget):
             "sort_state": json.loads(self.sort_state) if self.sort_state else None,
             "scroll_x": self.scroll_x,
         }
-        write_html(path, title, "Step Matrix", data, analysis)
 
 
 def _df_to_matrix(df) -> dict:

--- a/src/retentioneering/widgets/step_sankey.py
+++ b/src/retentioneering/widgets/step_sankey.py
@@ -6,7 +6,6 @@ from retentioneering.exceptions import RetentioneeringError
 from retentioneering.widgets._base import _UNSET, RetentioneeringWidget
 from retentioneering.widgets._utils import parse_diff as _parse_diff
 from retentioneering.widgets._utils import step_matrix_blocks as _step_matrix_blocks
-from retentioneering.widgets._html_export import write_html
 
 
 class StepSankeyWidget(RetentioneeringWidget):
@@ -218,32 +217,12 @@ class StepSankeyWidget(RetentioneeringWidget):
 
         return {"matrices": matrices, "event_counts": event_counts}
 
-    # ── HTML export ───────────────────────────────────────────────────────────
+    # ── HTML export (export_html/render_static: see RetentioneeringWidget) ────
 
-    def export_html(
-        self,
-        path: str,
-        title: str = "Step Sankey",
-        analysis: str | None = None,
-        sidebar_open: bool | None = None,
-    ) -> None:
-        """
-        Export the step sankey diagram as a standalone interactive HTML file.
+    _export_label = "Step Sankey"
 
-        Parameters
-        ----------
-        path:
-            Destination file path.
-        title:
-            Title shown in the browser tab.
-        analysis:
-            Optional analysis text. Supports basic markdown and [event] links.
-        sidebar_open:
-            Whether the settings sidebar starts open in the exported file.
-            Defaults to the widget's current ``sidebar_open`` value.
-        """
-        self._raise_if_error()
-        data = {
+    def _export_data(self, sidebar_open: bool | None = None) -> dict:
+        return {
             "widget_type": "step_sankey",
             "result": json.loads(self.result or "{}"),
             "max_steps": self.max_steps,
@@ -263,7 +242,6 @@ class StepSankeyWidget(RetentioneeringWidget):
             if sidebar_open is not None
             else self.sidebar_open,
         }
-        write_html(path, title, "Step Sankey", data, analysis)
 
 
 def _df_to_matrix(df) -> dict:

--- a/src/retentioneering/widgets/transition_graph.py
+++ b/src/retentioneering/widgets/transition_graph.py
@@ -5,7 +5,6 @@ import traitlets
 from retentioneering.exceptions import InvalidParameterError, RetentioneeringError
 from retentioneering.widgets._base import _UNSET, RetentioneeringWidget
 from retentioneering.widgets._utils import parse_diff as _parse_diff
-from retentioneering.widgets._html_export import write_html
 
 
 def _validate_view_events(view: dict, prefix: str, available: set) -> None:
@@ -360,40 +359,18 @@ class TransitionGraphWidget(RetentioneeringWidget):
             # of swallowing it so client code can at least log it.
             return {"result": {}, "error": str(exc)}
 
-    # ── HTML export ───────────────────────────────────────────────────────────
+    # ── HTML export (export_html/render_static: see RetentioneeringWidget) ────
 
-    def export_html(
-        self,
-        path: str,
-        title: str = "Transition Graph",
-        analysis: str | None = None,
-        sidebar_open: bool | None = None,
-    ) -> None:
-        """
-        Export the current graph as a standalone interactive HTML file.
+    _export_label = "Transition Graph"
 
-        Parameters
-        ----------
-        path:
-            Destination file path.
-        title:
-            Title shown in the browser tab.
-        analysis:
-            Optional analysis text. Wrap event names in square brackets to make
-            them clickable, e.g. `"Drop-off at [basket]: 78% of users leave here."`.
-            Supports basic markdown (bold, italic, bullet lists, tables, headings).
-        sidebar_open:
-            Whether the settings sidebar starts open in the exported file.
-            Defaults to the widget's current ``sidebar_open`` value.
-        """
-        self._raise_if_error()
+    def _export_data(self, sidebar_open: bool | None = None) -> dict:
         # A static export cannot call the graph_layout compute (no kernel), so
         # when the user hasn't arranged nodes by hand, bake the semantic
         # layout positions in at export time.
         node_positions = json.loads(self.node_positions or "{}")
         if not node_positions:
             node_positions = self.semantic_layout_positions()
-        data = {
+        return {
             "widget_type": "transition_graph",
             "widget_id": self.widget_id,
             "result": json.loads(self.result or "{}"),
@@ -419,7 +396,6 @@ class TransitionGraphWidget(RetentioneeringWidget):
             "views": json.loads(self.views or "[]"),
             "view": self.view,
         }
-        write_html(path, title, "Transition Graph", data, analysis)
 
 
 # ── helpers ────────────────────────────────────────────────────────────────────

--- a/tests/widgets/render_static_test.py
+++ b/tests/widgets/render_static_test.py
@@ -1,0 +1,110 @@
+"""``render_static()``: same payload as ``export_html()``, wrapped for a
+notebook cell's own output (survives ``jupyter nbconvert`` without a kernel).
+"""
+
+import html as html_mod
+import json
+import re
+
+import pandas as pd
+import pytest
+from IPython.core.display import HTML
+
+from retentioneering.eventstream.eventstream import Eventstream
+from retentioneering.widgets import _html_export
+from retentioneering.widgets._html_export import _ROOT_MARGIN_PX
+
+
+@pytest.fixture(autouse=True)
+def fake_bundle(tmp_path, monkeypatch):
+    bundle = tmp_path / "widget-static.js"
+    bundle.write_text("/* stub bundle */", encoding="utf-8")
+    monkeypatch.setattr(_html_export, "_BUNDLE_PATH", bundle)
+
+
+def _stream() -> Eventstream:
+    df = pd.DataFrame(
+        {
+            "user_id": [1, 1, 1, 2, 2],
+            "event": ["A", "B", "C", "A", "C"],
+            "timestamp": pd.date_range("2024-01-01", periods=5, freq="1min"),
+        }
+    )
+    return Eventstream(df)
+
+
+def _payload_from_iframe(rendered: HTML) -> dict:
+    assert isinstance(rendered, HTML)
+    m = re.match(
+        r'<iframe srcdoc="(.*)" style="([^"]*)"></iframe>'
+        r"<script>.*document\.currentScript\.previousElementSibling.*</script>$",
+        rendered.data,
+        re.DOTALL,
+    )
+    assert m, rendered.data
+    page = html_mod.unescape(m.group(1))
+    data_match = re.search(
+        r"<script>window\.__HS_DATA__ = (.*?);</script>", page, flags=re.DOTALL
+    )
+    assert data_match
+    resize_listener = "ResizeObserver" in page and "postMessage" in page
+    assert resize_listener, "exported page should report its height to the parent"
+    return json.loads(data_match.group(1)), m.group(2)
+
+
+class TestRenderStatic:
+    def test_transition_graph_matches_export_html(self, tmp_path):
+        widget = _stream().transition_graph()
+        out = tmp_path / "tg.html"
+        widget.export_html(str(out), title="t")
+        file_payload = re.search(
+            r"<script>window\.__HS_DATA__ = (.*?);</script>",
+            out.read_text(encoding="utf-8"),
+            flags=re.DOTALL,
+        )
+        assert file_payload
+
+        rendered = widget.render_static(title="t")
+        data, style = _payload_from_iframe(rendered)
+
+        assert json.loads(file_payload.group(1)) == data
+        # The iframe's starting height is the widget's own height *plus* the
+        # exported page's root margin, so the very first paint already
+        # matches what the page's own ResizeObserver would report — without
+        # this, every export starts short and visibly (if briefly) scrolls.
+        assert f"height:{widget.height + 2 * _ROOT_MARGIN_PX}px" in style
+
+    def test_custom_height_accepts_css_length(self):
+        # A caller-supplied CSS length (vs. a plain int) is used verbatim —
+        # only a widget's own pixel height gets the root-margin adjustment,
+        # since a CSS length isn't a "how tall is the content" measurement.
+        widget = _stream().transition_graph()
+        rendered = widget.render_static(height="80vh")
+        _, style = _payload_from_iframe(rendered)
+        assert "height:80vh" in style
+
+    def test_funnel_render_static(self):
+        widget = _stream().funnel(steps=["A", "C"])
+        data, _ = _payload_from_iframe(widget.render_static())
+        assert data["widget_type"] == "funnel"
+        assert data["steps"] == ["A", "C"]
+
+    def test_step_matrix_render_static(self):
+        widget = _stream().step_matrix()
+        data, _ = _payload_from_iframe(widget.render_static())
+        assert data["widget_type"] == "step_matrix"
+
+    def test_step_sankey_render_static(self):
+        widget = _stream().step_sankey()
+        data, _ = _payload_from_iframe(widget.render_static())
+        assert data["widget_type"] == "step_sankey"
+
+    def test_cluster_analysis_render_static(self):
+        widget = _stream().cluster_analysis()
+        data, _ = _payload_from_iframe(widget.render_static())
+        assert data["widget_type"] == "cluster_analysis"
+
+    def test_segment_overview_render_static(self):
+        widget = _stream().segment_overview(segment_col="user_id")
+        data, _ = _payload_from_iframe(widget.render_static())
+        assert data["widget_type"] == "segment_overview"


### PR DESCRIPTION
## Summary
- `jupyter nbconvert` / "Save and Export as HTML" replay a notebook's stored cell outputs without a kernel, so a live `anywidget` shows up blank or with a permanently-spinning "Updating graph..." overlay.
- New `RetentioneeringWidget.render_static()` (inherited by all six widgets) bakes the same self-contained page `export_html()` writes to disk into an `<iframe srcdoc>`, returned for direct use as a cell's own output — so it survives the notebook's own HTML export while staying fully interactive, no kernel required.
- The iframe self-sizes via a debounced `ResizeObserver`/`postMessage` handshake, with a starting-height margin correction — verified against a real headless Chromium build, not just unit tests, to rule out both a systematic under-height and a mount-time flash-to-near-zero.
- `export_html()`'s per-widget data-building logic is refactored into a shared `_export_data()`/`_export_label` extension point on the base class, reused by both `export_html()` and `render_static()`.
- Docs (`docs/guide/widgets.md`) add a "Rendering for a notebook's own HTML export" section, explicitly warning that without `state_file`, `render_static()` only sees the specific widget *object's* own traitlets — not a live in-browser arrangement (e.g. dragged transition-graph nodes) made on a different object with the same data/params.

## Test plan
- [x] `uv run pytest tests/ -v` — 719 passed, 1 skipped
- [x] `uv run pre-commit run --all-files` — ruff, ruff-format, gitleaks all pass
- [x] Built the real JS bundle (`make build`) and verified `render_static()`'s output in a real headless Chromium: iframe height stable at the correct value from the first observed frame through 2s+, zero internal scrollbar, `scrollHeight === offsetHeight`
- [x] Manual: open a notebook, drag transition-graph nodes with `state_file=` set, confirm `render_static()` (and a later widget instance built from the same `state_file`) reflects the arrangement