### PR TITLE
Bump version to 5.2.0 and guard the tag/pyproject mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,21 @@ jobs:
       - name: Build sdist and wheel
         run: uv build
 
+      # The build takes its version from pyproject.toml, not from the tag
+      # (ADR-0011: no dynamic versioning), so a tag pushed ahead of the version
+      # bump would silently rebuild the previous release. Catch that here
+      # rather than at `uv publish`, which fails with an opaque "File already
+      # exists" from PyPI. Assumes the tag is already a PEP 440-normalized
+      # version (`v5.2.0`, `v5.2.0rc1` -- not `v5.2.0-rc1`).
+      - name: Verify the built version matches the tag
+        run: |
+          set -e
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [ ! -f "dist/retentioneering-${VERSION}-py3-none-any.whl" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} doesn't match pyproject.toml's version -- built $(ls dist/*.whl). Bump pyproject.toml to ${VERSION}, then re-tag."
+            exit 1
+          fi
+
       - name: Verify the wheel embeds the JS bundle
         run: |
           set -e

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,14 @@ release:
 	       "rename '## [Unreleased]' to '## [$(VERSION)] - $$(date +%Y-%m-%d)' (and add a fresh" \
 	       "empty '## [Unreleased]' above it), then land that on master before releasing."; exit 1; \
 	fi
+	@# release.yml builds whatever pyproject.toml says, not what the tag says
+	@# (ADR-0011: no dynamic versioning). Without this check a tag pushed
+	@# ahead of the version bump republishes the *previous* version and the
+	@# run dies on PyPI's "File already exists".
+	@if ! grep -q '^version = "$(VERSION)"$$' pyproject.toml; then \
+	  echo "pyproject.toml says $$(grep -m1 '^version = ' pyproject.toml | cut -d'"' -f2), not $(VERSION)" \
+	       "-- bump it in the version-bump PR and land that on master before releasing."; exit 1; \
+	fi
 	git tag -a v$(VERSION) -m "Release v$(VERSION)"
 	git push origin v$(VERSION)
 	@echo "✓ Pushed tag v$(VERSION) -- release.yml will build and publish to PyPI."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "retentioneering"
-version = "5.1.0"
+version = "5.2.0"
 authors = [
   { name = "Retentioneering User Trajectory Analysis Lab", email = "retentioneering@gmail.com" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3168,7 +3168,7 @@ wheels = [
 
 [[package]]
 name = "retentioneering"
-version = "5.1.0"
+version = "5.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
## Why

`make release VERSION=5.2.0` produced a [failed run](https://github.com/retentioneering/retentioneering-tools/actions/runs/32267063911/job/96114025786) that tried to publish **5.1.0**.

The tag was cut while `pyproject.toml` still said `version = "5.1.0"`. `release.yml` builds from `pyproject.toml`, not from the tag (ADR-0011: no dynamic versioning), so `uv build` produced `retentioneering-5.1.0-py3-none-any.whl` and `uv publish` hit PyPI's `400 File already exists`. `make release` checked only the branch, the master sync, and the `## [5.2.0]` CHANGELOG section — never the version itself.

Nothing was published and the PyPI project is untouched; the run failed at step 11 and the release-notes/GitHub-Release steps were skipped.

## What

- `pyproject.toml` (+ the matching `uv.lock` entry): `5.1.0` → `5.2.0`.
- `make release` refuses unless `pyproject.toml`'s version equals `VERSION`, next to the existing CHANGELOG check.
- `release.yml` gains a `Verify the built version matches the tag` step between `uv build` and `uv publish`, so a tag pushed by hand past the Makefile is caught too — with a readable error instead of PyPI's 400.

`test-release` and `rc-release` are untouched: both `sed` the version into `pyproject.toml` right before tagging, so they can't drift.

## Note

The workflow check compares the tag against the wheel filename, so it assumes the tag is already PEP 440-normalized (`v5.2.0`, `v5.2.0rc1` — not `v5.2.0-rc1`); that's noted in a comment above the step. Every tag in the repo today follows that form.

## Testing

- Makefile guard exercised both ways on an isolated copy of the recipe: `VERSION=5.1.0` → `pyproject.toml says 5.2.0, not 5.1.0`, exit 1; `VERSION=5.2.0` → passes.
- `release.yml` parses and the step order is `uv build` → version check → JS-bundle check → `uv publish`.
- `uv lock --check` clean; `pre-commit` clean on the changed files.

## After merge

The bad `v5.2.0` tag still points at `292e39b` (version 5.1.0) and has to go before re-cutting:

```bash
git push origin :refs/tags/v5.2.0 && git tag -d v5.2.0
make release VERSION=5.2.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)