### PR TITLE
Widen max_steps when step_window asks for more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- [Step Matrix](https://retentioneering.com/docs/widgets/step-matrix) / [Step Sankey](https://retentioneering.com/docs/widgets/step-sankey): a `step_window` wider than `max_steps` showed fewer steps than asked for and gave no hint why. The window only ever sliced columns that `max_steps` had already computed, so past the computed depth — 10 by default — dragging the sidebar slider or passing `step_window=15` simply stopped having an effect. Asking for a deeper window now deepens the data instead: `max_steps` becomes `step_window + 10` (headroom, so the next notch or two costs nothing) and the matrix is recomputed. From an argument the widened depth is applied before the first compute, so it still costs a single pass; from the sidebar it triggers one recompute. Narrowing the window never shrinks `max_steps`, keeping the widening free to undo. The sidebar slider is no longer capped at the computed depth either — in a static HTML export it still is, since there is no kernel there to recompute with
+
 ## [5.2.0] - 2026-08-19
 
 ### Added

--- a/js/viz-core/src/components/SettingsSidebar/SettingsSidebar.tsx
+++ b/js/viz-core/src/components/SettingsSidebar/SettingsSidebar.tsx
@@ -119,6 +119,11 @@ export const SettingsSidebar = observer(function SettingsSidebar({
   // needing every future consumer to remember an opt-out prop.
   const showFocusDimming = typeof (store as { focusDimStrength?: unknown }).focusDimStrength === "number";
   const isDiff = store.matrixType === "differential";
+  // Upper bound of the Step window control. Asking for a window deeper than
+  // `maxSteps` makes Python widen `max_steps` and recompute, so the computed
+  // depth is a floor here, not a ceiling — except in a static export, which
+  // has no kernel to ask.
+  const stepWindowMax = isStatic ? Math.max(1, maxSteps ?? 1) : Math.max(20, maxSteps ?? 1);
   const isTime = isTimeValueType(valuesType);
 
   // Local (pending) diff state — not applied until the user clicks Apply
@@ -297,7 +302,7 @@ export const SettingsSidebar = observer(function SettingsSidebar({
         {/* Step window — shown only for step sankey */}
         {maxSteps != null && stepWindow != null && onStepWindowChange && (
           <div style={{ marginBottom: 20 }}>
-            <FieldLabel tooltip="Number of steps to display around each anchor event. Decreasing this hides outer columns without recomputing.">
+            <FieldLabel tooltip="Number of steps to display around each anchor event. Decreasing this hides outer columns without recomputing; going past the computed depth recomputes deeper instead of stopping there.">
               Step window
             </FieldLabel>
             <div style={{ fontSize: 12, color: C.muted, marginBottom: 8 }}>
@@ -305,15 +310,15 @@ export const SettingsSidebar = observer(function SettingsSidebar({
             </div>
             <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
               <div style={{ flex: 1 }}>
-                <SingleSlider min={1} max={maxSteps} value={stepWindow} onChange={onStepWindowChange} />
+                <SingleSlider min={1} max={stepWindowMax} value={stepWindow} onChange={onStepWindowChange} />
               </div>
               <input
                 type="number"
                 min={1}
-                max={maxSteps}
+                max={stepWindowMax}
                 value={stepWindow}
                 onChange={e => {
-                  const v = Math.max(1, Math.min(maxSteps, parseInt(e.target.value) || 1));
+                  const v = Math.max(1, Math.min(stepWindowMax, parseInt(e.target.value) || 1));
                   onStepWindowChange(v);
                 }}
                 style={{

--- a/js/widget/src/step_matrix.tsx
+++ b/js/widget/src/step_matrix.tsx
@@ -864,6 +864,7 @@ export function render({ host, el, isStatic = false }: RenderContext) {
 
     // ── display state ──────────────────────────────────────────────────────
     const [stepWindow,   setStepWindow]   = React.useState<number>(() => (host.get("step_window") as number) || 3);
+    const [maxSteps,     setMaxSteps]     = React.useState<number>(() => (host.get("max_steps") as number) ?? 10);
     const [hiddenEvents, setHiddenEvents] = React.useState<Set<string>>(() => {
       const vis = parseJson<Record<string, { isHidden?: boolean }>>(host.get("event_visibility") || "{}", {});
       return new Set(Object.keys(vis).filter(ev => vis[ev]?.isHidden));
@@ -911,12 +912,19 @@ export function render({ host, el, isStatic = false }: RenderContext) {
       ["height",       () => setHeight((host.get("height") as number) ?? 600)],
       ["sidebar_open", () => setSidebarOpen((host.get("sidebar_open") as boolean) ?? true)],
       ["step_window",  () => setStepWindow((host.get("step_window") as number) || 3)],
+      ["max_steps",    () => setMaxSteps((host.get("max_steps") as number) ?? 10)],
       ["path_col",  () => setPathIdCol((host.get("path_col") as string) || "")],
       ["path_pattern", () => { const v = (host.get("path_pattern") as string) || ""; setPathPattern(v); setAppliedPathPattern(v); }],
       ["diff",         () => { const d = parseJson<string[]>(host.get("diff") || "[]", []); setDiffSeg(d[0]??null); setDiffV1(d[1]??null); setDiffV2(d[2]??null); }],
     ]);
 
     const setParam = (key: string, val: unknown) => { host.set(key, val); };
+
+    // Upper bound of the Step window control. A live widget may ask for a
+    // window deeper than what `max_steps` computed — Python widens `max_steps`
+    // and recomputes — so the current depth is a floor, not a ceiling. A static
+    // export has no kernel to ask, so there it is a ceiling.
+    const stepWindowMax = isStatic ? Math.max(1, maxSteps) : Math.max(20, maxSteps);
     // Debounced variant for slider-driven params that change many times per drag
     const paramTimers = React.useRef<Record<string, ReturnType<typeof setTimeout>>>({});
     const setParamDebounced = (key: string, val: unknown, delay = 250) => {
@@ -924,33 +932,53 @@ export function render({ host, el, isStatic = false }: RenderContext) {
       paramTimers.current[key] = setTimeout(() => { host.set(key, val); }, delay);
     };
 
+    // Mirrors stepWindow for the imperative navigation API below, which runs
+    // outside the render cycle and so can't read the state variable itself.
+    const stepWindowRef = React.useRef(stepWindow);
+    React.useEffect(() => { stepWindowRef.current = stepWindow; }, [stepWindow]);
+    const maxStepsRef = React.useRef(maxSteps);
+    React.useEffect(() => { maxStepsRef.current = maxSteps; }, [maxSteps]);
+
     // Expose external navigation API for static HTML report links
     React.useEffect(() => {
       (el as any).__matrixApi = {
         scrollToCell: (eventName: string, step: number) => {
-          // Expand step_window if needed so the target column is visible
-          setStepWindow(prev => Math.max(prev, Math.abs(step)));
-          setTimeout(() => {
+          // Expand step_window if needed so the target column is visible. A
+          // live widget also tells Python, which deepens max_steps and
+          // recomputes when the target step lies past what was computed —
+          // hence the second, later attempt at finding the cell.
+          const next = Math.max(stepWindowRef.current, Math.abs(step));
+          const needsRecompute = !isStatic && next > maxStepsRef.current;
+          if (next !== stepWindowRef.current) {
+            stepWindowRef.current = next;
+            setStepWindow(next);
+            if (!isStatic) setParam("step_window", next);
+          }
+          const findAndHighlight = (): boolean => {
             const rows = el.querySelectorAll("tr[data-event]");
             for (let i = 0; i < rows.length; i++) {
               const row = rows[i] as HTMLElement;
-              if (row.dataset.event === eventName) {
-                const cell = row.querySelector(`td[data-step="${step}"]`) as HTMLElement | null;
-                if (cell) {
-                  cell.scrollIntoView({ block: "nearest", inline: "center", behavior: "smooth" });
-                  const prev = cell.style.background;
-                  cell.style.background = "#fef3c7";
-                  setTimeout(() => { cell.style.background = prev; }, 900);
-                } else {
-                  row.scrollIntoView({ block: "nearest", behavior: "smooth" });
-                }
-                break;
+              if (row.dataset.event !== eventName) continue;
+              const cell = row.querySelector(`td[data-step="${step}"]`) as HTMLElement | null;
+              if (cell) {
+                cell.scrollIntoView({ block: "nearest", inline: "center", behavior: "smooth" });
+                const prev = cell.style.background;
+                cell.style.background = "#fef3c7";
+                setTimeout(() => { cell.style.background = prev; }, 900);
+                return true;
               }
+              row.scrollIntoView({ block: "nearest", behavior: "smooth" });
+              return false;
             }
+            return false;
+          };
+          setTimeout(() => {
+            if (findAndHighlight() || !needsRecompute) return;
+            setTimeout(findAndHighlight, 1200);
           }, 150);
         },
       };
-    }, [setStepWindow]);
+    }, [setStepWindow, isStatic]);
 
     const applyDiff = () => {
       if (localDiffSeg && localDiffV1 && localDiffV2 && localDiffV1 !== localDiffV2) {
@@ -1147,11 +1175,11 @@ export function render({ host, el, isStatic = false }: RenderContext) {
               <SecHeader>Visibility Settings</SecHeader>
 
               <div style={{ marginBottom: 20 }}>
-                <FLabel tip="Steps visible on each side of the anchor column.">Step window</FLabel>
+                <FLabel tip="Steps visible on each side of the anchor column. Going past the computed depth recomputes the matrix deeper instead of stopping there.">Step window</FLabel>
                 <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-                  <div style={{ flex: 1 }}><SingleSlider min={1} max={20} value={stepWindow} onChange={w => { setStepWindow(w); setParamDebounced("step_window", w); }} /></div>
-                  <input type="number" min={1} max={20} value={stepWindow}
-                    onChange={e => { const w = Math.max(1, Math.min(20, parseInt(e.target.value) || 1)); setStepWindow(w); setParamDebounced("step_window", w); }}
+                  <div style={{ flex: 1 }}><SingleSlider min={1} max={stepWindowMax} value={stepWindow} onChange={w => { setStepWindow(w); setParamDebounced("step_window", w); }} /></div>
+                  <input type="number" min={1} max={stepWindowMax} value={stepWindow}
+                    onChange={e => { const w = Math.max(1, Math.min(stepWindowMax, parseInt(e.target.value) || 1)); setStepWindow(w); setParamDebounced("step_window", w); }}
                     style={{ width: 52, border: `1px solid ${SC.borderLight}`, borderRadius: 6, padding: "5px 8px", fontSize: 13, textAlign: "center", outline: "none", background: SC.bg, color: SC.text, boxShadow: "inset 0 1px 2px rgba(0,0,0,0.04)" }} />
                 </div>
               </div>

--- a/js/widget/src/step_sankey.tsx
+++ b/js/widget/src/step_sankey.tsx
@@ -134,6 +134,15 @@ export function render({ host, el, isStatic = false }: RenderContext) {
       setPathIdCol(col); host.set("path_col", col);
     }, []);
 
+    // The slider fires per mouse-move; a window past `max_steps` now makes
+    // Python recompute deeper, so only the settled value is sent over.
+    const stepWindowTimer = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const handleStepWindowChange = React.useCallback((w: number) => {
+      setStepWindow(w);
+      clearTimeout(stepWindowTimer.current);
+      stepWindowTimer.current = setTimeout(() => host.set("step_window", w), 250);
+    }, []);
+
     const handleToggleSidebar = React.useCallback(() => {
       setSidebarOpen((prev) => { const next = !prev; host.set("sidebar_open", next); return next; });
     }, []);
@@ -188,10 +197,7 @@ export function render({ host, el, isStatic = false }: RenderContext) {
             theme="light"
             stepWindow={stepWindow}
             maxSteps={maxSteps}
-            onStepWindowChange={(w) => {
-              setStepWindow(w);
-              host.set("step_window", w);
-            }}
+            onStepWindowChange={handleStepWindowChange}
             isStatic={isStatic}
           />
         )}

--- a/src/retentioneering/eventstream/eventstream.py
+++ b/src/retentioneering/eventstream/eventstream.py
@@ -1891,7 +1891,10 @@ class Eventstream:
             single block and is mutually exclusive with `path_pattern`. See
             `step_sankey_data`.
         step_window : int, default 3
-            Number of step columns shown around each anchor.
+            Number of step columns shown around each anchor. Only slices what
+            `max_steps` computed, so a window wider than that — set here or in
+            the sidebar — raises `max_steps` to `step_window + 10` and
+            recomputes.
         diff : tuple or list, optional
             Draws a comparative chart for a pair of segments; see
             [Diff mode](/docs/widgets#diff-mode). `(segment_col, value1, value2)` or
@@ -1977,7 +1980,10 @@ class Eventstream:
             single block and is mutually exclusive with `path_pattern`. See
             `step_sankey_data`.
         step_window : int, default 3
-            Number of step columns shown around each anchor.
+            Number of step columns shown around each anchor. Only slices what
+            `max_steps` computed, so a window wider than that — set here or in
+            the sidebar — raises `max_steps` to `step_window + 10` and
+            recomputes.
         height : int, default 600
             Widget height in pixels.
         sidebar_open : bool, default True

--- a/src/retentioneering/widgets/_utils.py
+++ b/src/retentioneering/widgets/_utils.py
@@ -75,3 +75,22 @@ def parse_diff(raw) -> list | None:
     except Exception:
         pass
     return None
+
+
+#: Extra steps computed beyond a requested `step_window`, so that widening the
+#: window by a notch or two costs nothing rather than a recompute per notch.
+STEP_WINDOW_HEADROOM = 10
+
+
+def max_steps_for_window(step_window: int, max_steps: int) -> int:
+    """`max_steps` wide enough to fill a `step_window`-column view.
+
+    `step_window` only slices columns that `max_steps` already computed, so a
+    window wider than the data silently shows fewer steps than asked for. When
+    that happens, grow `max_steps` past the window instead — see
+    `STEP_WINDOW_HEADROOM`. Never shrinks: a narrowed window keeps whatever
+    depth was already computed, so widening it back is instant.
+    """
+    if step_window > max_steps:
+        return step_window + STEP_WINDOW_HEADROOM
+    return max_steps

--- a/src/retentioneering/widgets/step_matrix.py
+++ b/src/retentioneering/widgets/step_matrix.py
@@ -4,6 +4,7 @@ import traitlets
 
 from retentioneering.exceptions import RetentioneeringError
 from retentioneering.widgets._base import _UNSET, RetentioneeringWidget
+from retentioneering.widgets._utils import max_steps_for_window as _max_steps_for_window
 from retentioneering.widgets._utils import parse_diff as _parse_diff
 from retentioneering.widgets._utils import pattern_edges as _pattern_edges
 from retentioneering.widgets._utils import step_matrix_blocks as _step_matrix_blocks
@@ -123,6 +124,11 @@ class StepMatrixWidget(RetentioneeringWidget):
             }
         )
 
+        # A window wider than the computed depth would silently show fewer
+        # steps than asked for; widen the depth instead, before the first
+        # compute, so an argument-supplied window costs no extra pass.
+        self.max_steps = _max_steps_for_window(self.step_window, self.max_steps)
+
         self._recompute()
         self._initialized = True
 
@@ -130,6 +136,7 @@ class StepMatrixWidget(RetentioneeringWidget):
             self._on_params_change,
             names=["max_steps", "diff", "path_col", "path_pattern", "anchor"],
         )
+        self.observe(self._on_step_window_change, names=["step_window"])
         self._start_state_autosave()
 
     def _anchor_spec(self):
@@ -160,6 +167,14 @@ class StepMatrixWidget(RetentioneeringWidget):
             self.anchor = ""
             return
         self._recompute()
+
+    def _on_step_window_change(self, _change):
+        """A window widened from the sidebar past the computed depth deepens
+        the data to match; the extra columns don't exist otherwise. Setting
+        `max_steps` is itself observed, which is what triggers the recompute."""
+        if not self._initialized:
+            return
+        self.max_steps = _max_steps_for_window(self.step_window, self.max_steps)
 
     # ── dispatch ───────────────────────────────────────────────────────────────
 

--- a/src/retentioneering/widgets/step_sankey.py
+++ b/src/retentioneering/widgets/step_sankey.py
@@ -4,6 +4,7 @@ import traitlets
 
 from retentioneering.exceptions import RetentioneeringError
 from retentioneering.widgets._base import _UNSET, RetentioneeringWidget
+from retentioneering.widgets._utils import max_steps_for_window as _max_steps_for_window
 from retentioneering.widgets._utils import parse_diff as _parse_diff
 from retentioneering.widgets._utils import step_matrix_blocks as _step_matrix_blocks
 
@@ -111,6 +112,11 @@ class StepSankeyWidget(RetentioneeringWidget):
             }
         )
 
+        # A window wider than the computed depth would silently show fewer
+        # steps than asked for; widen the depth instead, before the first
+        # compute, so an argument-supplied window costs no extra pass.
+        self.max_steps = _max_steps_for_window(self.step_window, self.max_steps)
+
         self._recompute()
 
         self._initialized = True
@@ -119,6 +125,7 @@ class StepSankeyWidget(RetentioneeringWidget):
             names=["max_steps", "diff", "path_col", "path_pattern", "anchor"],
         )
         self.observe(self._on_positions_change, names=["node_positions"])
+        self.observe(self._on_step_window_change, names=["step_window"])
         self._start_state_autosave()
 
     def _anchor_spec(self):
@@ -149,6 +156,14 @@ class StepSankeyWidget(RetentioneeringWidget):
             self.anchor = ""
             return
         self._recompute()
+
+    def _on_step_window_change(self, _change):
+        """A window widened from the sidebar past the computed depth deepens
+        the data to match; the extra columns don't exist otherwise. Setting
+        `max_steps` is itself observed, which is what triggers the recompute."""
+        if not self._initialized:
+            return
+        self.max_steps = _max_steps_for_window(self.step_window, self.max_steps)
 
     def _on_positions_change(self, _change):
         if not self._initialized:

--- a/tests/widgets/_utils_test.py
+++ b/tests/widgets/_utils_test.py
@@ -1,6 +1,10 @@
 """Tests for widgets/_utils.py helpers."""
 
-from retentioneering.widgets._utils import parse_diff, pattern_edges
+from retentioneering.widgets._utils import (
+    max_steps_for_window,
+    parse_diff,
+    pattern_edges,
+)
 
 
 class TestParseDiff:
@@ -61,3 +65,18 @@ class TestPatternEdges:
 
     def test__a_sentinel_inside_a_class_is_not_the_part_boundary(self) -> None:
         assert pattern_edges("[path_start|home]->cart") == (False, False)
+
+
+class TestMaxStepsForWindow:
+    def test__window_within_the_computed_depth_changes_nothing(self) -> None:
+        assert max_steps_for_window(3, 10) == 10
+        assert max_steps_for_window(10, 10) == 10
+
+    def test__window_past_the_computed_depth_adds_headroom(self) -> None:
+        assert max_steps_for_window(15, 10) == 25
+        assert max_steps_for_window(11, 10) == 21
+
+    def test__never_shrinks(self) -> None:
+        """A narrowed window keeps the depth already computed, so widening it
+        back is free."""
+        assert max_steps_for_window(1, 25) == 25

--- a/tests/widgets/step_window_test.py
+++ b/tests/widgets/step_window_test.py
@@ -1,0 +1,113 @@
+"""`step_window` only slices columns `max_steps` already computed, so a window
+wider than the computed depth has to deepen it instead of silently showing
+fewer steps than asked for."""
+
+import json
+
+import pandas as pd
+import pytest
+
+from retentioneering.eventstream.eventstream import Eventstream
+from retentioneering.widgets.step_matrix import StepMatrixWidget
+from retentioneering.widgets.step_sankey import StepSankeyWidget
+
+WIDGETS = [StepMatrixWidget, StepSankeyWidget]
+
+
+def _stream() -> Eventstream:
+    """One 40-event path, deep enough for any window these tests ask for."""
+    ts = pd.Timestamp("2024-01-01")
+    rows = [
+        {
+            "user_id": "u1",
+            "event": f"e{i % 4}",
+            "timestamp": ts + pd.Timedelta(minutes=i),
+        }
+        for i in range(40)
+    ]
+    return Eventstream(pd.DataFrame(rows))
+
+
+def _last_column(widget) -> int:
+    return json.loads(widget.result)["matrices"][0]["columns"][-1]
+
+
+def _count_computes(monkeypatch, widget_cls) -> list[int]:
+    """The `max_steps` each `_compute_raw` call ran with, in order."""
+    seen: list[int] = []
+    original = widget_cls._compute_raw
+
+    def spy(self, max_steps, *args, **kwargs):
+        seen.append(max_steps)
+        return original(self, max_steps, *args, **kwargs)
+
+    monkeypatch.setattr(widget_cls, "_compute_raw", spy)
+    return seen
+
+
+@pytest.mark.parametrize("widget_cls", WIDGETS)
+class TestStepWindowExpandsMaxSteps:
+    def test__window_argument_deepens_max_steps(self, widget_cls) -> None:
+        widget = widget_cls(_stream(), step_window=15)
+
+        assert widget.error == ""
+        assert widget.max_steps == 25
+        assert _last_column(widget) == 25
+
+    def test__window_argument_costs_one_pass(self, widget_cls, monkeypatch) -> None:
+        """Taken into account immediately: the widened depth is what the first
+        compute runs with, not a second pass after it."""
+        seen = _count_computes(monkeypatch, widget_cls)
+
+        widget_cls(_stream(), step_window=15)
+
+        assert seen == [25]
+
+    def test__explicit_max_steps_wide_enough_is_left_alone(self, widget_cls) -> None:
+        widget = widget_cls(_stream(), max_steps=30, step_window=15)
+
+        assert widget.max_steps == 30
+        assert _last_column(widget) == 30
+
+    def test__window_from_the_sidebar_deepens_and_recomputes(self, widget_cls) -> None:
+        widget = widget_cls(_stream())
+        assert widget.max_steps == 10
+
+        widget.step_window = 15  # what the sidebar slider sets
+
+        assert widget.error == ""
+        assert widget.max_steps == 25
+        assert _last_column(widget) == 25
+
+    def test__narrowing_the_window_keeps_the_computed_depth(
+        self, widget_cls, monkeypatch
+    ) -> None:
+        widget = widget_cls(_stream(), step_window=15)
+        seen = _count_computes(monkeypatch, widget_cls)
+
+        widget.step_window = 2
+
+        assert widget.max_steps == 25
+        assert seen == []  # narrowing is pure slicing, done in the browser
+
+    def test__window_within_the_computed_depth_does_not_recompute(
+        self, widget_cls, monkeypatch
+    ) -> None:
+        widget = widget_cls(_stream())
+        seen = _count_computes(monkeypatch, widget_cls)
+
+        widget.step_window = 10
+
+        assert widget.max_steps == 10
+        assert seen == []
+
+    def test__the_widened_depth_is_what_gets_exported(self, widget_cls) -> None:
+        """A static export has no kernel to deepen anything later, so the
+        columns the window needs have to be in the exported result already."""
+        widget = widget_cls(_stream(), step_window=15)
+
+        data = widget._export_data()
+
+        assert data["max_steps"] == 25
+        assert data["step_window"] == 15
+        assert data["result"]["matrices"][0]["columns"][-1] == 25


### PR DESCRIPTION
## The bug

`step_window` only slices columns that `max_steps` already computed. Past the computed depth — 10 by default — it stopped having any effect: `step_matrix(step_window=15)` showed 10 steps, and dragging the sidebar slider past 10 changed nothing, with no hint why. Step Sankey had the same problem from the other side: its slider was hard-capped at `max_steps`, so the depth could not be asked for at all.

## The fix

A window wider than the computed depth now deepens the data instead of being silently truncated: `max_steps` becomes `step_window + 10` — headroom, so widening by another notch or two costs no recompute — and the matrix is recomputed.

- **From an argument** the widened depth is applied *before* the first compute, so it still costs a single pass.
- **From the sidebar** it triggers one recompute, through the `max_steps` observer that was already wired up.
- **Narrowing never shrinks `max_steps`**, which keeps the widening free to undo.

The rule lives in one place — `widgets/_utils.max_steps_for_window` — and both widgets apply it identically.

### JS

- The Step window control is no longer capped at the computed depth. Its ceiling is `max(20, max_steps)` and grows as Python deepens, so the slider keeps going instead of stopping at the current data. A **static export keeps the old cap** — there is no kernel behind it to recompute with.
- Step Sankey's slider debounces its writes (250 ms). It used to `host.set` on every mouse-move, which was free when the value only sliced columns and is not any more.
- `scrollToCell` (the navigation API behind report links) now tells Python about the window it expands, rather than only widening it locally, and retries finding the cell once if a recompute was needed to bring the column into existence.

## Testing

- `tests/widgets/step_window_test.py` — 14 tests, parametrized over both widgets: expansion from the argument, "one pass only" (a spy on `_compute_raw`), an explicit wide `max_steps` left alone, expansion from the sidebar, no recompute when narrowing or when the window fits, and the widened result being what `export_html` embeds.
- Unit tests for the helper in `tests/widgets/_utils_test.py`.
- Full suite: 1424 passed, 1 skipped. `pre-commit --all-files` clean. `make build` builds both bundles.

Verified by hand: `step_matrix(step_window=15)` → `max_steps=25`, columns `0..25`; Sankey with `path_pattern` → `-22..22`; exported HTML carries `"max_steps": 25`. No browser-level check — there is no JS test harness in the repo and no playwright in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)