### PR TITLE
docs: note that truncate_paths offsets accept negative values

### DIFF
--- a/src/retentioneering/eventstream/eventstream.py
+++ b/src/retentioneering/eventstream/eventstream.py
@@ -1418,8 +1418,9 @@ class Eventstream:
           to be a single position; it is for `add_events(anchor=...)`.
         - `offset` — move the anchor off the matched event: an int shifts it that
           many events, a duration string or `pd.Timedelta` (`"30m"`) shifts it in
-          time and then snaps to the nearest event *inside* the window. An offset
-          that runs past the path's own boundary clamps to it.
+          time and then snaps to the nearest event *inside* the window. Negative
+          values (`-2`, `"-30m"`) shift backwards, widening the window past the
+          anchor. An offset that runs past the path's own boundary clamps to it.
         - `offset_side` — which way a time `offset` rounds to a real event,
           `"start"` (forward) or `"end"` (backward). Defaults to the side of the
           window being resolved, which rounds inward; set it to widen instead.


### PR DESCRIPTION
Negative offsets already work on both sides of a window bound — an int shifts the anchor backwards through steps, a duration ("-30m") backwards through time, and running past the path's start clamps to the first event the same way a forward offset clamps to the last. The docstring only described the forward case, so widening a window past its anchor looked unsupported.


Claude-Session: https://claude.ai/code/session_014R2FQmgTAiTDH4972f3fdc

<!-- Thanks for contributing to retentioneering! Keep the PR focused on one logical change. -->

## What & why

<!-- One to three sentences. Link the issue this addresses: Fixes #NNN -->

## Before / after

<!-- For a bug fix: a minimal repro and the behavior before vs after.
     For a feature: the use case and the new usage. -->

## Checklist

- [ ] Ran `make install-dev` (one-time per clone) so the git hook is active
- [ ] `uv run pre-commit run --all-files` passes (ruff lint + format, hygiene, gitleaks) — this is CI's `lint` job
- [ ] `uv run pytest tests/ -q` passes
- [ ] Added/updated tests (a bug fix includes the failing-before test)
- [ ] Docstrings updated and, if they changed, `uv run python docs/scripts/render_pages.py` re-run
- [ ] Added an entry under `CHANGELOG.md`'s `[Unreleased]` section (skip only for docs/CI/internal-only changes)
- [ ] Sync obligations handled where applicable (MCP tool layer, JS metric editor / widget contract)

## Breaking changes

<!-- None, or describe them plus a migration note. Note: PRs target `master`; releases are tag-driven. -->
